### PR TITLE
Use static APP_URL for QR share links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1411,6 +1411,7 @@
     <script>
         // Global State Management
         const APP_VERSION = '2.0.0';
+        const APP_URL = 'https://clovenbradshaw-ctrl.github.io/ikey4/';
         const WEBHOOK_URL = 'https://n8n.intelechia.com/webhook/d5e99c29-2cf1-44c1-b5b4-95a1ca048441';
         
         const state = {
@@ -1784,7 +1785,7 @@
                 return;
             }
             
-            const qrData = `${window.location.origin}${window.location.pathname}#${state.currentGUID}:${btoa(String.fromCharCode(...state.baseKey))}`;
+            const qrData = `${APP_URL}#${state.currentGUID}:${encodeURIComponent(btoa(String.fromCharCode(...state.baseKey)))}`;
             
             const container = document.getElementById('setup-qrcode');
             container.innerHTML = '';
@@ -2374,7 +2375,7 @@
                 return;
             }
             
-            const qrData = `${window.location.origin}${window.location.pathname}#${state.currentGUID}:${btoa(String.fromCharCode(...state.baseKey))}`;
+            const qrData = `${APP_URL}#${state.currentGUID}:${encodeURIComponent(btoa(String.fromCharCode(...state.baseKey)))}`;
             
             document.getElementById('qr-display').classList.remove('hidden');
             const container = document.getElementById('main-qrcode');


### PR DESCRIPTION
## Summary
- Define `APP_URL` constant for consistent base URL use.
- Update setup and main QR generation to rely on `APP_URL` and URI-encoded keys.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b4af2fea708332b85900d5cf0fa079