### PR TITLE
Load emergency data from URL fragment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1443,16 +1443,31 @@
 
         // Initialize Application
         async function init() {
+            const fragment = window.location.hash.substring(1);
+            if (fragment) {
+                const [guid, keyBase64] = fragment.split(':');
+                if (guid && keyBase64) {
+                    state.baseKey = Uint8Array.from(atob(keyBase64), c => c.charCodeAt(0));
+                    state.currentGUID = guid;
+                    await loadPublicData();
+                    displayEmergencyInfo();
+
+                    // Setup keyboard listeners for PIN entry
+                    setupKeyboardListeners();
+                    return;
+                }
+            }
+
             // Check if first time user
             const hasGUID = localStorage.getItem('ikey_guid');
-            
+
             if (!hasGUID) {
                 state.isFirstTime = true;
                 showSetupWizard();
             } else {
                 await loadExistingUser();
             }
-            
+
             // Setup keyboard listeners for PIN entry
             setupKeyboardListeners();
         }


### PR DESCRIPTION
## Summary
- Initialize app from URL fragment when present
- Decode base key and GUID from fragment to load public data immediately
- Skip setup wizard for shared emergency view

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_68b4af451a408332bb00a5248b242f9c