### PR TITLE
Add emergency data fetching and sample endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -1443,16 +1443,44 @@
 
         // Initialize Application
         async function init() {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const [guid, keyB64] = hash.split(':');
+                if (guid && keyB64) {
+                    try {
+                        state.currentGUID = guid;
+                        state.baseKey = Uint8Array.from(atob(keyB64), c => c.charCodeAt(0));
+                        state.isShareMode = true;
+                        document.body.classList.add('share-mode');
+
+                        let encrypted = localStorage.getItem(`ikey_${guid}_public`);
+                        if (!encrypted) {
+                            encrypted = await fetchPublicData(guid);
+                            if (!encrypted) return; // Error already shown
+                        }
+                        encrypted = JSON.parse(encrypted);
+
+                        state.publicData = await decrypt(encrypted, state.baseKey);
+                        displayEmergencyInfo();
+                        return;
+                    } catch (error) {
+                        console.error('Hash access failed:', error);
+                        showStatus('Unable to load emergency data', 'error');
+                        return;
+                    }
+                }
+            }
+
             // Check if first time user
             const hasGUID = localStorage.getItem('ikey_guid');
-            
+
             if (!hasGUID) {
                 state.isFirstTime = true;
                 showSetupWizard();
             } else {
                 await loadExistingUser();
             }
-            
+
             // Setup keyboard listeners for PIN entry
             setupKeyboardListeners();
         }
@@ -1924,6 +1952,21 @@
         }
 
         // Data Loading/Saving
+        async function fetchPublicData(guid) {
+            try {
+                const response = await fetch(`${WEBHOOK_URL}/${guid}`);
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const payload = await response.json();
+                if (!payload || !payload.public) throw new Error('Invalid payload');
+                localStorage.setItem(`ikey_${guid}_public`, payload.public);
+                return payload.public;
+            } catch (error) {
+                console.error('Failed to fetch public data:', error);
+                showStatus('Unable to retrieve emergency data', 'error');
+                return null;
+            }
+        }
+
         async function loadPublicData() {
             try {
                 const stored = localStorage.getItem(`ikey_${state.currentGUID}_public`);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,32 @@
+const http = require('http');
+
+// In-memory store of encrypted public payloads
+// In production, replace with a database or persistent storage
+const emergencyStore = {
+  'demo-guid': JSON.stringify({
+    iv: 'demoiv==',
+    data: 'demodata=='
+  })
+};
+
+const server = http.createServer((req, res) => {
+  const guid = decodeURIComponent(req.url.slice(1));
+
+  if (req.method === 'GET' && guid) {
+    const payload = emergencyStore[guid];
+    if (!payload) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'Not found' }));
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify({ public: payload }));
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Public data endpoint listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Add Node.js server with GET /:guid endpoint returning encrypted public payloads
- Implement fetchPublicData to retrieve emergency data when absent locally
- Update init hash handling to fetch and decrypt emergency data, showing errors on failures
- Simplify fetchPublicData to return raw payload and parse consistently in hash handling

## Testing
- `node server.js &`
- `curl -s http://localhost:3000/demo-guid | python -m json.tool`


------
https://chatgpt.com/codex/tasks/task_b_68b4af463b0c8332b8fbc8261ed02956