### PR TITLE
Serve index document from server

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 const http = require('http');
+const fs = require('fs');
+const path = require('path');
 
 // In-memory store of encrypted public payloads
 // In production, replace with a database or persistent storage
@@ -9,7 +11,14 @@ const emergencyStore = {
   })
 };
 
+const indexHtml = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+
 const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && (req.url === '/' || req.url === '/index.html')) {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    return res.end(indexHtml);
+  }
+
   const guid = decodeURIComponent(req.url.slice(1));
 
   if (req.method === 'GET' && guid) {


### PR DESCRIPTION
## Summary
- load `index.html` within the Node server and serve it at `/` for a self-contained app
- keep GUID endpoint for returning stored public data

## Testing
- `node server.js &`
- `curl -s http://localhost:3000 | head -n 5`
- `curl -s http://localhost:3000/demo-guid`


------
https://chatgpt.com/codex/tasks/task_b_68b4b6e5238c8332a51ba3b26ce0f854