### PR TITLE
Add local API server integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ state = {
 
 ### Endpoint Configuration
 
-- **Base URL**: `https://n8n.intelechia.com/webhook/d5e99c29-2cf1-44c1-b5b4-95a1ca048441`
+- **Base URL**: `/api` (served by `server.js`; update `WEBHOOK_URL` in `index.html` if using an external webhook)
 - **POST Method**: Creates new record (first sync for new GUID)
 - **PUT Method**: Updates existing record (subsequent syncs for existing GUID)
 
@@ -382,19 +382,21 @@ if (!window.crypto || !window.crypto.subtle) {
 
 ### Static Hosting
 
-The application is a single HTML file that can be:
-- Hosted on any static web server
-- Saved locally and run from file://
-- Deployed to GitHub Pages, Netlify, Vercel
-- Embedded in native apps via WebView
-- Distributed via IPFS for decentralization
+The application is a single HTML file that can be served directly by the bundled
+Node server or hosted on any static platform:
+- Run `node server.js` and visit `http://localhost:3000`
+- Serve from any static web server
+- Save locally and run from `file://`
+- Deploy to GitHub Pages, Netlify, Vercel
+- Embed in native apps via WebView
+- Distribute via IPFS for decentralization
 
 ### Configuration
 
 No server-side configuration required. Optional webhook endpoint can be modified in the code:
 
 ```javascript
-const WEBHOOK_URL = 'https://n8n.intelechia.com/webhook/d5e99c29-2cf1-44c1-b5b4-95a1ca048441';
+const WEBHOOK_URL = '/api';
 ```
 
 ## Future Enhancements

--- a/index.html
+++ b/index.html
@@ -1358,8 +1358,8 @@
     <script>
         // Global State Management
         const APP_VERSION = '2.0.0';
-        const APP_URL = 'https://clovenbradshaw-ctrl.github.io/ikey4/';
-        const WEBHOOK_URL = 'https://n8n.intelechia.com/webhook/d5e99c29-2cf1-44c1-b5b4-95a1ca048441';
+        const APP_URL = window.location.origin + '/';
+        const WEBHOOK_URL = '/api';
         const AUTO_LOGOUT_MS = 45 * 60 * 1000;
         
         const state = {

--- a/server.js
+++ b/server.js
@@ -2,30 +2,68 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
-// In-memory store of encrypted public payloads
+// In-memory store of encrypted payloads
 // In production, replace with a database or persistent storage
 const emergencyStore = {
-  'demo-guid': 'demoiv==.demodata=='
+  'demo-guid': { data: 'demoiv==.demodata==', hash: null }
 };
 
 const indexHtml = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
 
 const server = http.createServer((req, res) => {
-  if (req.method === 'GET' && (req.url === '/' || req.url === '/index.html')) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  // Serve the application
+  if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
     res.writeHead(200, { 'Content-Type': 'text/html' });
     return res.end(indexHtml);
   }
 
-  const guid = decodeURIComponent(req.url.slice(1));
+  // API endpoint for sync and restore
+  if (url.pathname === '/api') {
+    if (req.method === 'GET') {
+      const guid = url.searchParams.get('guid');
+      const entry = guid && emergencyStore[guid];
+      if (!entry) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'Not found' }));
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ data: entry.data }));
+    }
 
-  if (req.method === 'GET' && guid) {
-    const payload = emergencyStore[guid];
-    if (!payload) {
+    if (req.method === 'POST' || req.method === 'PUT') {
+      let body = '';
+      req.on('data', chunk => (body += chunk));
+      req.on('end', () => {
+        try {
+          const { guid, data, nextHash } = JSON.parse(body);
+          if (!guid || !data) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            return res.end(JSON.stringify({ error: 'Invalid payload' }));
+          }
+          emergencyStore[guid] = { data, hash: nextHash };
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok' }));
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        }
+      });
+      return;
+    }
+  }
+
+  // Fallback: treat path as GUID for public access
+  if (req.method === 'GET' && url.pathname.length > 1) {
+    const guid = decodeURIComponent(url.pathname.slice(1));
+    const entry = emergencyStore[guid];
+    if (!entry) {
       res.writeHead(404, { 'Content-Type': 'application/json' });
       return res.end(JSON.stringify({ error: 'Not found' }));
     }
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    return res.end(JSON.stringify({ data: payload }));
+    return res.end(JSON.stringify({ data: entry.data }));
   }
 
   res.writeHead(404, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary
- Serve index.html through a Node HTTP server that also exposes a `/api` endpoint for syncing and retrieving encrypted records.
- Point the client to the local API and derive the application URL from the current host.
- Document running the bundled server and updated webhook endpoint in the README.

## Testing
- `curl -s http://localhost:3000/api?guid=demo-guid` returns stored demo payload.
- `curl -s -X POST -H "Content-Type: application/json" -d '{"guid":"test-guid","data":"payload","nextHash":"hash"}' http://localhost:3000/api` stores new record.
- `curl -s http://localhost:3000/api?guid=test-guid` retrieves stored record.
- `curl -s http://localhost:3000/ | head -n 5` serves index.html.


------
https://chatgpt.com/codex/tasks/task_b_68b4cf5dabdc8332bac8846bc1d83823