### PR TITLE
Use PIN pad modal during setup wizard

### DIFF
--- a/index.html
+++ b/index.html
@@ -973,15 +973,9 @@
                         </div>
                         <div class="form-group">
                             <label>Enter 6-Digit PIN</label>
-                        <input type="password"
-                               id="setup-pin"
-                               pattern="[0-9]{6}"
-                               maxlength="6"
-                               placeholder="6 digits"
-                               class="pin-input"
-                               inputmode="numeric"
-                               readonly
-                               onclick="requestPIN('setup')">
+                            <button type="button" class="btn" onclick="requestPINForSetup()">Set PIN</button>
+                            <div id="setup-pin-display" style="display:none;">PIN Set ✓</div>
+                            <input type="hidden" id="setup-pin">
                             <small>Easy to remember, for non-sensitive updates</small>
                         </div>
                     </div>
@@ -2151,6 +2145,14 @@
         // PIN Management
         let pinCallback = null;
 
+        function requestPINForSetup() {
+            pinCallback = 'setup';
+            document.getElementById('pin-modal').classList.add('active');
+            document.getElementById('pin-modal-title').textContent = 'Set Your 6-Digit PIN';
+            pinEntry = '';
+            updatePinDisplay();
+        }
+
         function requestPIN(action) {
             if (state.pinUnlocked && action !== 'change' && action !== 'recovery' && action !== 'setup') {
                 if (action === 'edit') editEmergencyInfo();
@@ -2172,12 +2174,7 @@
                 updatePinDisplay();
 
                 if (pinEntry.length === 6) {
-                    if (pinCallback === 'setup') {
-                        document.getElementById('setup-pin').value = pinEntry;
-                        closePinPad();
-                    } else {
-                        setTimeout(verifyPIN, 100);
-                    }
+                    setTimeout(verifyPIN, 100);
                 }
             }
         }
@@ -2202,6 +2199,12 @@
         }
 
         async function verifyPIN() {
+            if (pinCallback === 'setup') {
+                document.getElementById('setup-pin').value = pinEntry;
+                document.getElementById('setup-pin-display').style.display = 'block';
+                closePinPad();
+                return;
+            }
             try {
                 const derivedKey = await deriveKeyFromPIN(pinEntry);
                 


### PR DESCRIPTION
## Summary
- Replace Step 3 PIN text field with a button to open the PIN pad modal and hidden storage input.
- Add `requestPINForSetup` and streamline PIN digit handling to route through `verifyPIN`.
- Extend `verifyPIN` to store the setup PIN and show confirmation during wizard.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5c8791a948332a6878c46d4a4958a