### PR TITLE
Fix PIN modal overlay stacking over setup wizard

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,7 +432,7 @@
             display: none;
             justify-content: center;
             align-items: center;
-            z-index: 2000;
+            z-index: 3500;
         }
 
         .modal-overlay.active {


### PR DESCRIPTION
## Summary
- Increase `z-index` of `.modal-overlay` so the PIN modal displays above the setup wizard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5c98edac0833297eee5cc32153dc7