### PR TITLE
Add fixed status bar for updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -714,43 +714,54 @@
             margin: 16px 0;
         }
 
-        .status-message {
-            padding: 12px 16px;
-            border-radius: 8px;
-            margin: 16px 0;
+        .status-bar {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            background: var(--surface);
+            border-radius: 12px;
+            padding: 10px 16px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            z-index: 2000;
+            min-width: 200px;
+            max-width: 300px;
+            opacity: 0;
+            transform: translateY(20px);
+            transition: all 0.3s ease;
+            pointer-events: none;
+        }
+
+        .status-bar.active {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        .status-content {
             display: flex;
             align-items: center;
             gap: 8px;
-            animation: slideIn 0.3s ease;
+            font-size: 0.875rem;
+            font-weight: 500;
         }
 
-        @keyframes slideIn {
-            from {
-                opacity: 0;
-                transform: translateY(-10px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
+        .status-bar.success {
+            background: var(--success);
+            color: white;
         }
 
-        .status-success {
-            background: rgba(16, 185, 129, 0.1);
-            color: var(--success);
-            border: 1px solid var(--success);
+        .status-bar.error {
+            background: var(--danger);
+            color: white;
         }
 
-        .status-error {
-            background: rgba(239, 68, 68, 0.1);
-            color: var(--danger);
-            border: 1px solid var(--danger);
+        .status-bar.info {
+            background: var(--primary);
+            color: white;
         }
 
-        .status-info {
-            background: rgba(79, 70, 229, 0.1);
-            color: var(--primary);
-            border: 1px solid var(--primary);
+        .status-bar.warning {
+            background: var(--warning);
+            color: white;
         }
 
         .sync-indicator {
@@ -2981,15 +2992,29 @@
 
         // Utility Functions
         function showStatus(message, type = 'info') {
-            const status = document.createElement('div');
-            status.className = `status-message status-${type}`;
-            status.textContent = message;
-            
-            document.querySelector('.container').insertBefore(status, document.querySelector('.container').firstChild);
-            
-            setTimeout(() => {
-                status.remove();
-            }, 3000);
+            const statusBar = document.getElementById('status-bar');
+            const statusText = document.getElementById('status-text');
+            const statusIcon = document.getElementById('status-icon');
+
+            const icons = {
+                success: '✓',
+                error: '✗',
+                warning: '⚠',
+                info: 'ℹ',
+                sync: '↻'
+            };
+
+            statusIcon.textContent = icons[type] || icons.info;
+            statusText.textContent = message;
+
+            statusBar.className = 'status-bar active ' + type;
+
+            clearTimeout(window.statusTimeout);
+            if (type !== 'sync') {
+                window.statusTimeout = setTimeout(() => {
+                    statusBar.classList.remove('active');
+                }, 3000);
+            }
         }
 
         function updateSecurityUI() {
@@ -3179,5 +3204,12 @@
             sessionStorage.removeItem('ikey_session_active');
         });
     </script>
+    <!-- Status Bar -->
+    <div id="status-bar" class="status-bar">
+        <div class="status-content">
+            <span id="status-icon">✓</span>
+            <span id="status-text">Ready</span>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace inline status messages with a reusable fixed status bar
- provide dedicated styles for success, error, info, and warning notifications
- update `showStatus` to drive the status bar with icons and timed auto-hide

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5d45185a48332b1f8174a07f2df67