### PR TITLE
Implement recovery key file regeneration on credential changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,7 @@ https://example.com/ikey.html#a1b2c3d4-e5f6-7890-abcd-ef1234567890:SGVsbG9Xb3JsZ
 
 ## Recovery Mechanisms
 
-Recovery options based on a secure key file are under active development.
-At present, forgotten PINs or passwords cannot be recovered.
+A recovery key file provides an alternate login path if your PIN or password is lost. The key file is automatically downloaded during setup and whenever you change your PIN or EHR password. It is encrypted using the application's base URL—store it securely as a new key file is required after each credential change.
 
 ## User Experience Features
 

--- a/index.html
+++ b/index.html
@@ -2286,6 +2286,7 @@
                 processingOverlay.querySelector('.processing-message').textContent = 'Syncing to cloud...';
                 
                 await saveAllData();
+                await downloadKeyFile();
                 
                 // Final message
                 processingOverlay.querySelector('.processing-message').textContent = '✓ Setup complete!';
@@ -2450,6 +2451,45 @@
                 codes.push(Math.random().toString(36).substring(2, 8).toUpperCase());
             }
             return codes;
+        }
+
+        async function deriveKeyFromURL(url) {
+            const encoder = new TextEncoder();
+            const data = encoder.encode(url);
+            const hash = await crypto.subtle.digest('SHA-256', data);
+            return new Uint8Array(hash);
+        }
+
+        async function downloadKeyFile() {
+            if (!state.baseKey || !state.currentGUID) return;
+            const urlKey = await deriveKeyFromURL(APP_URL);
+            const keyData = {
+                guid: state.currentGUID,
+                baseKey: btoa(String.fromCharCode(...state.baseKey))
+            };
+            const encrypted = await encrypt(keyData, urlKey);
+            const blob = new Blob([encrypted], { type: 'text/plain' });
+            const link = document.createElement('a');
+            link.href = URL.createObjectURL(blob);
+            link.download = `ikey-key-${state.currentGUID}.ikey`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            alert('Recovery key file downloaded. Keep it secure for alternate login.');
+        }
+
+        async function refreshBaseKey() {
+            state.baseKey = await generateKey();
+            localStorage.setItem(`ikey_basekey_${state.currentGUID}`,
+                btoa(String.fromCharCode(...state.baseKey)));
+            const storedPin = localStorage.getItem(`ikey_pin_temp_${state.currentGUID}`) || '';
+            if (storedPin) {
+                state.currentDoubleHash = await generateDoubleHash(state.baseKey, storedPin);
+                const encryptedHash = await encrypt({ hash: state.currentDoubleHash }, state.baseKey);
+                localStorage.setItem(`ikey_hash_${state.currentGUID}`, encryptedHash);
+            }
+            await saveAllData();
+            await downloadKeyFile();
         }
 
         // Encryption/Decryption
@@ -2829,6 +2869,11 @@
                 await loadProtectedData();
                 state.pinAttemptsRemaining = 5;
 
+                if (pinCallback === 'change') {
+                    await refreshBaseKey();
+                    showStatus('PIN changed successfully', 'success');
+                }
+
                 if (pinCallback === 'edit') {
                     editEmergencyInfo();
                 }
@@ -2938,7 +2983,8 @@
                     await saveSecureData();
                     unlockPasswordLevel();
                     closePasswordModal();
-                    showStatus('Password set successfully', 'success');
+                    await refreshBaseKey();
+                    showStatus(action === 'change' ? 'Password changed successfully' : 'Password set successfully', 'success');
                 }
             } catch (error) {
                 alert('Failed to process password');


### PR DESCRIPTION
## Summary
- Generate recovery key file encrypted with base URL
- Auto-download key file on setup and after PIN/password changes
- Refresh base key when credentials update, ensuring new key files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5da8e216483328c716910c0231ada