### PR TITLE
Validate local profile before loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ localStorage:
 └── ikey_[GUID]_lastSync              # Last cloud sync timestamp
 ```
 
+### Starting Fresh
+
+To create a new profile or bypass saved data, open the application with `?setup=new` in the URL. This forces the setup wizard even if a previous instance exists.
+
 ### Data Structure
 
 ```javascript

--- a/index.html
+++ b/index.html
@@ -1826,15 +1826,33 @@
     }
     
     // Only check localStorage if NO hash in URL
-    const hasGUID = localStorage.getItem('ikey_guid');
-    
-    if (!hasGUID) {
-        // No saved instance and no hash - show wizard
+    const params = new URLSearchParams(window.location.search);
+    const forceSetup = params.get('setup') === 'new';
+    const savedGUID = localStorage.getItem('ikey_guid');
+
+    if (forceSetup) {
         state.isFirstTime = true;
         showSetupWizard();
+    } else if (savedGUID) {
+        const baseKey = localStorage.getItem(`ikey_basekey_${savedGUID}`);
+        const publicData = localStorage.getItem(`ikey_${savedGUID}_public`);
+        if (baseKey && publicData) {
+            await loadExistingUser();
+        } else {
+            // Corrupted instance - clean up and show wizard
+            localStorage.removeItem('ikey_guid');
+            localStorage.removeItem(`ikey_basekey_${savedGUID}`);
+            localStorage.removeItem(`ikey_${savedGUID}_public`);
+            localStorage.removeItem(`ikey_${savedGUID}_protected`);
+            localStorage.removeItem(`ikey_${savedGUID}_secure`);
+            localStorage.removeItem(`ikey_hash_${savedGUID}`);
+            localStorage.removeItem(`ikey_pin_temp_${savedGUID}`);
+            state.isFirstTime = true;
+            showSetupWizard();
+        }
     } else {
-        // Load the saved instance ONLY if no hash
-        await loadExistingUser();
+        state.isFirstTime = true;
+        showSetupWizard();
     }
 
     // Setup keyboard listeners and activity tracking


### PR DESCRIPTION
## Summary
- Validate saved GUID instance by ensuring base key and public data exist before loading
- Add `?setup=new` URL parameter to force the setup wizard and clean up corrupted data
- Document how to start a fresh profile

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b73a200b648332b8e965a589b3dd08