### PR TITLE
fix: improve theme contrast for text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,11 @@
             --glass-border: rgba(255, 255, 255, 0.2);
             --gac: #8B5CF6;
 
+            /* Ensure inputs have proper colors */
+            --input-bg: #FFFFFF;
+            --input-text: #111827;
+            --input-border: #E5E7EB;
+
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
         }
@@ -69,6 +74,14 @@
             --text-secondary: #cc0000;
             --border: #ff0000;
             --glass: rgba(0, 0, 0, 0.95);
+            --glass-border: rgba(255, 0, 0, 0.2);
+            --gac: #ff6666;
+
+            /* Fix input visibility */
+            --input-bg: #0d0d0d;
+            --input-text: #ff0000;
+            --input-border: #ff0000;
+
             background: #000;
             font-family: 'Arial', sans-serif;
         }
@@ -127,11 +140,21 @@
             --primary-dark: #00cc00;
             --danger: #ff0000;
             --success: #00ff00;
+            --warning: #ffff00;
             --surface: #000000;
             --surface-alt: #0a0a0a;
             --text: #00ff00;
             --text-secondary: #00cc00;
             --border: #00ff00;
+            --glass: rgba(0, 0, 0, 0.95);
+            --glass-border: rgba(0, 255, 0, 0.2);
+            --gac: #00ff00;
+
+            /* Fix input visibility */
+            --input-bg: #0a0a0a;
+            --input-text: #00ff00;
+            --input-border: #00ff00;
+
             background: #000;
             font-family: 'Consolas', 'Monaco', monospace;
         }
@@ -169,21 +192,26 @@
             color: #00ff00;
         }
 
-        body.theme-hacker .btn {
-            text-shadow: 0 0 10px #00ff00;
-            border: 1px solid #00ff00;
-            background: transparent;
-        }
-
         body.theme-wellness {
             --primary: #7c9885;
             --primary-dark: #5a7261;
+            --danger: #d9534f;
             --success: #a8c09a;
+            --warning: #f0ad4e;
             --surface: #faf8f3;
             --surface-alt: #f0ede5;
             --text: #3d4a3d;
             --text-secondary: #6b7c6b;
             --border: #d4cfc0;
+            --glass: rgba(250, 248, 243, 0.95);
+            --glass-border: rgba(212, 207, 192, 0.3);
+            --gac: #8fa68f;
+
+            /* Fix input visibility */
+            --input-bg: #faf8f3;
+            --input-text: #3d4a3d;
+            --input-border: #d4cfc0;
+
             background: linear-gradient(135deg, #faf8f3 0%, #e8e2d5 100%);
             font-family: 'Segoe UI', 'San Francisco', sans-serif;
         }
@@ -214,21 +242,48 @@
 
         body.theme-contrast {
             --primary: #000000;
+            --primary-dark: #000000;
             --danger: #000000;
             --success: #000000;
+            --warning: #000000;
             --surface: #ffffff;
             --surface-alt: #ffffff;
             --text: #000000;
             --text-secondary: #000000;
             --border: #000000;
+            --glass: rgba(255, 255, 255, 1);
+            --glass-border: #000000;
+            --gac: #000000;
+
+            /* Fix input visibility */
+            --input-bg: #ffffff;
+            --input-text: #000000;
+            --input-border: #000000;
+
+            background: #ffffff;
         }
 
         body.theme-contrast.dark-mode {
             --primary: #ffffff;
+            --primary-dark: #ffffff;
+            --danger: #ffffff;
+            --success: #ffffff;
+            --warning: #ffffff;
             --surface: #000000;
             --surface-alt: #000000;
             --text: #ffffff;
+            --text-secondary: #ffffff;
             --border: #ffffff;
+            --glass: rgba(0, 0, 0, 1);
+            --glass-border: #ffffff;
+            --gac: #ffffff;
+
+            /* Fix input visibility */
+            --input-bg: #000000;
+            --input-text: #ffffff;
+            --input-border: #ffffff;
+
+            background: #000000;
         }
 
         body.theme-contrast * {
@@ -248,10 +303,24 @@
 
         body.theme-retro {
             --primary: #4a7c59;
+            --primary-dark: #3a5c49;
+            --danger: #c0392b;
+            --success: #27ae60;
+            --warning: #f39c12;
             --surface: #f4f1e8;
             --surface-alt: #e8ddc7;
             --text: #2d2d2d;
+            --text-secondary: #5d5d5d;
             --border: #9b8f7e;
+            --glass: rgba(244, 241, 232, 0.95);
+            --glass-border: rgba(155, 143, 126, 0.3);
+            --gac: #6a9c79;
+
+            /* Fix input visibility */
+            --input-bg: #f4f1e8;
+            --input-text: #2d2d2d;
+            --input-border: #9b8f7e;
+
             background: #f4f1e8;
             font-family: 'American Typewriter', 'Courier', serif;
         }
@@ -276,6 +345,11 @@
             border: 3px double #4a7c59;
             border-radius: 50%;
             text-transform: uppercase;
+        }
+
+        body.theme-topsecret .btn,
+        body.theme-hacker .btn {
+            text-shadow: 0 0 2px currentColor;
         }
 
         .container {
@@ -449,6 +523,7 @@
 
         .header {
             background: var(--surface);
+            color: var(--text);
             border-radius: calc(12px * var(--element-scale));
             padding: calc(12px * var(--spacing-scale));
             margin-bottom: calc(12px * var(--spacing-scale));
@@ -482,6 +557,9 @@
             align-items: center;
             gap: 4px;
             font-weight: 600;
+            background: var(--surface-alt);
+            color: var(--text);
+            border: 1px solid var(--border);
         }
 
         .badge-public {
@@ -511,7 +589,7 @@
         .nav-tab {
             background: var(--surface);
             color: var(--text);
-            border: none;
+            border: 1px solid var(--border);
             padding: 14px 18px;
             border-radius: 10px;
             cursor: pointer;
@@ -585,11 +663,12 @@
         .form-group select {
             width: 100%;
             padding: calc(12px * var(--spacing-scale)) calc(14px * var(--spacing-scale));
-            border: 2px solid var(--border);
+            border: 2px solid var(--input-border, var(--border));
             border-radius: calc(8px * var(--element-scale));
             font-size: calc(1rem * var(--text-scale));
             transition: all 0.2s;
-            background: var(--surface);
+            background: var(--input-bg, var(--surface));
+            color: var(--input-text, var(--text));
             min-height: calc(48px * var(--element-scale));
             touch-action: manipulation;
         }
@@ -600,6 +679,36 @@
             outline: none;
             border-color: var(--primary);
             box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+            background: var(--input-bg, var(--surface));
+            color: var(--input-text, var(--text));
+        }
+
+        .form-group input::placeholder,
+        .form-group textarea::placeholder {
+            color: var(--text-secondary);
+            opacity: 0.6;
+        }
+
+        body.theme-topsecret select option,
+        body.theme-hacker select option {
+            background: var(--surface);
+            color: var(--text);
+        }
+
+        body.theme-topsecret .form-group input,
+        body.theme-topsecret .form-group textarea,
+        body.theme-topsecret .form-group select {
+            background: #0d0d0d;
+            color: #ff0000;
+            border: 2px solid #ff0000;
+        }
+
+        body.theme-hacker .form-group input,
+        body.theme-hacker .form-group textarea,
+        body.theme-hacker .form-group select {
+            background: #0a0a0a;
+            color: #00ff00;
+            border: 2px solid #00ff00;
         }
 
         .size-controls {
@@ -624,7 +733,7 @@
             padding: calc(14px * var(--spacing-scale)) calc(24px * var(--spacing-scale));
             background: var(--primary);
             color: white;
-            border: none;
+            border: 1px solid var(--primary);
             border-radius: calc(10px * var(--element-scale));
             font-size: calc(1rem * var(--text-scale));
             font-weight: 600;
@@ -679,6 +788,7 @@
 
         .info-card {
             background: var(--surface-alt);
+            border: 1px solid var(--border);
             border-radius: 10px;
             padding: 14px;
             margin-bottom: 12px;
@@ -729,9 +839,10 @@
         }
 
         .modal-container {
-            background: var(--glass);
+            background: var(--surface);
+            color: var(--text);
+            border: 1px solid var(--border);
             backdrop-filter: blur(20px);
-            border: 1px solid var(--glass-border);
             border-radius: 20px;
             padding: 24px 16px;
             width: 100%;
@@ -794,8 +905,8 @@
         }
 
         .pin-key {
-            background: rgba(79, 70, 229, 0.1);
-            border: 2px solid rgba(79, 70, 229, 0.3);
+            background: var(--surface-alt);
+            border: 2px solid var(--primary);
             border-radius: 14px;
             padding: 0;
             font-size: 1.8rem;
@@ -813,24 +924,22 @@
         }
 
         .pin-key:hover {
-            background: rgba(79, 70, 229, 0.2);
+            background: var(--primary);
+            color: white;
             transform: scale(1.05);
         }
 
         .pin-key:active {
             transform: scale(0.95);
-            background: rgba(79, 70, 229, 0.3);
         }
 
         .pin-key.special-clear {
-            background: rgba(239, 68, 68, 0.1);
-            border-color: rgba(239, 68, 68, 0.3);
+            border-color: var(--danger);
             font-size: 1.2rem;
         }
 
         .pin-key.special-cancel {
-            background: rgba(107, 114, 128, 0.1);
-            border-color: rgba(107, 114, 128, 0.3);
+            border-color: var(--border);
             font-size: 1.2rem;
         }
 
@@ -1008,6 +1117,8 @@
             bottom: 20px;
             right: 20px;
             background: var(--surface);
+            color: var(--text);
+            border: 1px solid var(--border);
             border-radius: 12px;
             padding: 10px 16px;
             box-shadow: 0 4px 12px rgba(0,0,0,0.15);


### PR DESCRIPTION
## Summary
- add missing CSS variables and input color tokens for all themes
- standardize form inputs, buttons, and UI components to use theme colors
- ensure modals, tabs, info cards, and status bar maintain readable contrast
- set explicit backgrounds for high-contrast themes to preserve readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b8c60aa2c48332991321b5ec8395fa