### PR TITLE
Adjust text colors for hacker and top secret themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
             --warning: #ffaa00;
             --surface: #1a0000;
             --surface-alt: #2d0000;
-            --text: #ffffff;
+            --text: #ff3333;
             --text-secondary: #ff9999;
             --border: #660000;
             --glass: rgba(0, 0, 0, 0.95);
@@ -141,8 +141,8 @@
             --success: #00ff00;
             --surface: #0a1a0a;
             --surface-alt: #132613;
-            --text: #b3ffb3;
-            --text-secondary: #66ff66;
+            --text: #ffffff;
+            --text-secondary: #ffffff;
             --border: #004400;
             background: #0a1a0a;
             font-family: 'Consolas', 'Monaco', monospace;


### PR DESCRIPTION
## Summary
- Ensure Midnight Hacker theme text uses white for better visibility.
- Set Top Secret theme text color to red to match theme style.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b8ccd586cc833286bcb6ccf28f19f0