### PR TITLE
Rename security tab and move to end

### DIFF
--- a/index.html
+++ b/index.html
@@ -1463,11 +1463,11 @@
             <button class="nav-tab locked" onclick="showTab('health')" data-tab="health" id="healthTab">
                 🏥 Health Info
             </button>
-            <button class="nav-tab locked" onclick="showTab('security')" data-tab="security" id="securityTab">
-                🔒 Security &amp; Access
-            </button>
             <button class="nav-tab locked hidden" onclick="showTab('ehr')" data-tab="ehr" id="ehrTab">
                 📋 Full EHR
+            </button>
+            <button class="nav-tab locked" onclick="showTab('security')" data-tab="security" id="securityTab">
+                🔒 Security &amp; Settings
             </button>
         </div>
 
@@ -1538,7 +1538,7 @@
         <!-- Security Section (PIN Tier) -->
         <div class="content-section" id="security-section">
             <div class="section-header">
-                <h2>Security & Access</h2>
+                <h2>Security & Settings</h2>
             </div>
             
             <div class="mb-4">


### PR DESCRIPTION
## Summary
- Rename "Security & Access" to "Security & Settings" in navigation and section heading.
- Move the security tab to the far right of the navigation bar after the EHR tab.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b8ccef5fe483328994df59f837d773