### PR TITLE
Log data source for cloud restore

### DIFF
--- a/index.html
+++ b/index.html
@@ -2668,6 +2668,7 @@
             ];
 
             for (const src of sources) {
+                console.info(`Attempting to retrieve data from ${src.name}: ${src.url}`);
                 try {
                     const json = await fetchWithRetry(src.url);
                     const payload = src.extract(json);
@@ -2688,6 +2689,7 @@
                     }
 
                     state.telemetry.lastRestoreSource = src.name;
+                    console.info(`Successfully restored data from ${src.name}`);
                     showStatus(`Data restored from ${src.name}`, 'success');
                     return allData;
                 } catch (err) {


### PR DESCRIPTION
## Summary
- Add console logging to show which remote source (Xano, Archive.org, Webhook) is used during data restoration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b8ee92733c83328920a1a420c848ac