### PR TITLE
Add PIN lockout tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -1435,6 +1435,8 @@
         const XANO_CACHE_URL = 'https://xvkq-pq7i-idtl.n7d.xano.io/api:Hj4C6PGO/ikey_cache';
         const ARCHIVE_BASE_URL = 'https://archive.org/download/zuboff';
         const AUTO_LOGOUT_MS = 45 * 60 * 1000;
+        const MAX_ATTEMPTS = 5;
+        const LOCKOUT_DURATION = 15 * 60 * 1000;
         let pinEntry = '';
 
         const state = {
@@ -1452,8 +1454,6 @@
                 lastRestoreSource: null,
                 lastSyncResults: {}
             },
-
-            pinAttemptsRemaining: 5,
 
             publicData: {
                 emergency: {}
@@ -2620,6 +2620,46 @@
             });
         }
 
+        function checkLockout() {
+            const guid = state.currentGUID || 'default';
+            const attemptsKey = `ikey_pin_attempts_${guid}`;
+            const lockoutKey = `ikey_pin_lockout_${guid}`;
+            const lockoutUntil = parseInt(localStorage.getItem(lockoutKey) || '0', 10);
+            if (lockoutUntil) {
+                if (Date.now() < lockoutUntil) {
+                    const remainingMs = lockoutUntil - Date.now();
+                    const minutes = Math.ceil(remainingMs / 60000);
+                    showStatus(`Too many failed attempts. Try again in ${minutes} minute${minutes !== 1 ? 's' : ''}.`, 'error');
+                    return true;
+                } else {
+                    localStorage.removeItem(lockoutKey);
+                }
+            }
+            const attempts = parseInt(localStorage.getItem(attemptsKey) || '0', 10);
+            if (attempts > 0) {
+                const remaining = MAX_ATTEMPTS - attempts;
+                showStatus(`${remaining} attempts remaining`, 'error');
+            }
+            return false;
+        }
+
+        function handleFailedAttempt() {
+            const guid = state.currentGUID || 'default';
+            const attemptsKey = `ikey_pin_attempts_${guid}`;
+            const lockoutKey = `ikey_pin_lockout_${guid}`;
+            let attempts = parseInt(localStorage.getItem(attemptsKey) || '0', 10);
+            attempts++;
+            if (attempts >= MAX_ATTEMPTS) {
+                localStorage.setItem(lockoutKey, Date.now() + LOCKOUT_DURATION);
+                localStorage.removeItem(attemptsKey);
+                showStatus('Too many failed attempts. Locked out for 15 minutes.', 'error');
+            } else {
+                localStorage.setItem(attemptsKey, attempts.toString());
+                const remaining = MAX_ATTEMPTS - attempts;
+                showStatus(`Wrong PIN. ${remaining} attempts remaining`, 'error');
+            }
+        }
+
         async function verifyPIN() {
             // Handle setup flow
             if (pinAction === 'setup') {
@@ -2640,6 +2680,12 @@
                     resolver(tempPin);
                     return;
                 }
+            }
+
+            if (checkLockout()) {
+                pinEntry = '';
+                updatePinDisplay();
+                return;
             }
 
             // Standard verification
@@ -2664,7 +2710,9 @@
                     }
 
                     closePinPad();
-                    state.pinAttemptsRemaining = 5;
+                    const guid = state.currentGUID || 'default';
+                    localStorage.removeItem(`ikey_pin_attempts_${guid}`);
+                    localStorage.removeItem(`ikey_pin_lockout_${guid}`);
 
                     if (pinAction === 'edit') {
                         editEmergencyInfo();
@@ -2684,15 +2732,16 @@
                 }
 
             } catch (error) {
-                state.pinAttemptsRemaining--;
-                showStatus(`Wrong PIN. ${state.pinAttemptsRemaining} attempts remaining`, 'error');
+                handleFailedAttempt();
                 document.querySelectorAll('#pinDisplay .pin-dot').forEach(dot => dot.classList.add('error'));
                 setTimeout(() => {
                     pinEntry = '';
                     updatePinDisplay();
                 }, 1000);
 
-                if (state.pinAttemptsRemaining <= 0 && window.pinPromiseReject) {
+                const guid = state.currentGUID || 'default';
+                const lockoutUntil = parseInt(localStorage.getItem(`ikey_pin_lockout_${guid}`) || '0', 10);
+                if (lockoutUntil && Date.now() < lockoutUntil && window.pinPromiseReject) {
                     const rejector = window.pinPromiseReject;
                     window.pinPromiseResolve = null;
                     window.pinPromiseReject = null;


### PR DESCRIPTION
## Summary
- define MAX_ATTEMPTS and LOCKOUT_DURATION constants
- add checkLockout and handleFailedAttempt using localStorage for PIN attempts
- reset lockout state on successful verification and block on too many failures

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68c0ce9b96b883329960d5e55b4c76ad