### PR TITLE
Switch to password-based auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,7 @@
             color: var(--text-secondary);
         }
 
-        .badge-pin {
+        .badge-password {
             background: rgba(79, 70, 229, 0.1);
             color: var(--primary);
         }
@@ -784,90 +784,13 @@
             font-weight: 500;
         }
 
-        .pin-display {
-            display: flex;
-            justify-content: center;
-            gap: 16px;
-            margin: 32px auto;
-            max-width: 320px;
-        }
-
-        .pin-dot {
-            width: 24px;
-            height: 24px;
-            border-radius: 50%;
-            background: rgba(79, 70, 229, 0.2);
-            border: 2px solid rgba(79, 70, 229, 0.3);
-            transition: all 0.3s;
-        }
-
-        .pin-dot.filled {
-            background: var(--primary);
-            transform: scale(1.3);
-            box-shadow: 0 0 20px rgba(79, 70, 229, 0.5);
-        }
-
-        .pin-dot.error {
-            background: var(--danger);
-            animation: shake 0.5s;
-        }
-
-        @keyframes shake {
-            0%, 100% { transform: translateX(0); }
-            25% { transform: translateX(-5px); }
-            75% { transform: translateX(5px); }
-        }
-
-        .pin-keypad {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 10px;
-            margin-bottom: 20px;
-            max-width: 360px;
-            margin-left: auto;
-            margin-right: auto;
-            padding: 0 8px;
-        }
-
-        .pin-key {
-            background: rgba(79, 70, 229, 0.1);
-            border: 2px solid rgba(79, 70, 229, 0.3);
-            border-radius: 14px;
-            padding: 0;
-            font-size: 1.8rem;
-            color: var(--text);
-            cursor: pointer;
-            transition: all 0.2s;
-            font-weight: bold;
-            min-height: 65px;
-            height: 65px;
+        .password-input {
             width: 100%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            touch-action: manipulation;
-        }
-
-        .pin-key:hover {
-            background: rgba(79, 70, 229, 0.2);
-            transform: scale(1.05);
-        }
-
-        .pin-key:active {
-            transform: scale(0.95);
-            background: rgba(79, 70, 229, 0.3);
-        }
-
-        .pin-key.special-clear {
-            background: rgba(239, 68, 68, 0.1);
-            border-color: rgba(239, 68, 68, 0.3);
-            font-size: 1.2rem;
-        }
-
-        .pin-key.special-cancel {
-            background: rgba(107, 114, 128, 0.1);
-            border-color: rgba(107, 114, 128, 0.3);
-            font-size: 1.2rem;
+            padding: 12px;
+            font-size: 1.5rem;
+            margin: 32px auto;
+            display: block;
+            text-align: center;
         }
 
 
@@ -973,21 +896,6 @@
             50% { opacity: 0.5; }
         }
 
-        .pin-reset-link {
-            text-align: center;
-            margin-top: 12px;
-            font-size: 0.875rem;
-        }
-
-        .pin-reset-link a {
-            color: var(--primary);
-            text-decoration: none;
-            cursor: pointer;
-        }
-
-        .pin-reset-link a:hover {
-            text-decoration: underline;
-        }
 
         .qr-container {
             text-align: center;
@@ -1102,13 +1010,13 @@
                     <div class="info-card">
                         <span class="info-card-icon">📝</span>
                         <div class="info-card-content">
-                            <div class="info-card-label">Level 2: Demographics (PIN)</div>
-                            <div class="info-card-value">Contact info and basic details - protected by 6-digit PIN</div>
+                            <div class="info-card-label">Level 2: Demographics (Password)</div>
+                            <div class="info-card-value">Contact info and basic details - protected by password</div>
                         </div>
                     </div>
 
                     <div class="warning-box">
-                        <strong>Important:</strong> Your PIN IS your encryption key. It cannot be recovered if lost. Store it safely.
+                        <strong>Important:</strong> Your password IS your encryption key. It cannot be recovered if lost. Store it safely.
                     </div>
                 </div>
                 
@@ -1194,17 +1102,17 @@
                     <div class="security-tier-card">
                         <div class="tier-header">
                             <span class="tier-icon">📝</span>
-                            <h3>Level 1: PIN (Demographics)</h3>
+                            <h3>Level 1: Password (Demographics)</h3>
                         </div>
                         <div class="tier-info">
                             <p><strong>Protects:</strong> Contact info, address, phone numbers, non-medical updates</p>
-                            <p><strong>Why PIN is OK here:</strong> Lower risk data, convenience for frequent updates</p>
+                            <p><strong>Why a password is OK here:</strong> Lower risk data, convenience for frequent updates</p>
                         </div>
                         <div class="form-group">
-                            <label>Enter 6-Digit PIN</label>
-                            <button type="button" class="btn" onclick="requestPINForSetup()">Set PIN</button>
-                            <div id="setup-pin-display" style="display:none;">PIN Set ✓</div>
-                            <input type="hidden" id="setup-pin">
+                            <label>Create Password</label>
+                            <button type="button" class="btn" onclick="requestPasswordForSetup()">Set Password</button>
+                            <div id="setup-password-display" style="display:none;">Password Set ✓</div>
+                            <input type="hidden" id="setup-password">
                             <small>Easy to remember, for non-sensitive updates</small>
                         </div>
                     </div>
@@ -1307,7 +1215,7 @@
             </div>
             <div id="emergency-display"></div>
             <div class="btn-group mt-4">
-                <button class="btn" onclick="requestPIN('edit')">
+                <button class="btn" onclick="requestPassword('edit')">
                     🔐 Edit Information
                 </button>
                 <button class="btn btn-outline" onclick="generateMainQR()">
@@ -1324,7 +1232,7 @@
             </div>
         </div>
 
-        <!-- Health Section (PIN Tier) -->
+        <!-- Health Section (Password Tier) -->
         <div class="content-section" id="health-section">
             <div class="section-header">
                 <h2>Health Information</h2>
@@ -1356,16 +1264,16 @@
             
         </div>
 
-        <!-- Security Section (PIN Tier) -->
+        <!-- Security Section (Password Tier) -->
         <div class="content-section" id="security-section">
             <div class="section-header">
                 <h2>Security & Settings</h2>
             </div>
             
             <div class="mb-4">
-                <h3>PIN Management</h3>
+                <h3>Password Management</h3>
                 <p style="color: var(--text-secondary); margin-top: 8px; font-size: 0.875rem;">
-                    Set and manage your PIN for accessing protected health data.
+                    Set and manage your password for accessing protected health data.
                 </p>
             </div>
             
@@ -1384,35 +1292,16 @@
 
     </div>
 
-    <!-- PIN Modal -->
-    <div id="pin-modal" class="modal-overlay">
+    <!-- Password Modal -->
+    <div id="password-modal" class="modal-overlay">
         <div class="modal-container">
-            <h3 class="modal-title" id="pin-modal-title">Enter 6-Digit PIN</h3>
-            
-            <div class="pin-display" id="pinDisplay">
-                <div class="pin-dot"></div>
-                <div class="pin-dot"></div>
-                <div class="pin-dot"></div>
-                <div class="pin-dot"></div>
-                <div class="pin-dot"></div>
-                <div class="pin-dot"></div>
+            <h3 class="modal-title" id="password-modal-title">Enter Password</h3>
+            <input type="password" id="password-input" class="password-input"
+                   onkeydown="if(event.key==='Enter'){verifyPassword();}">
+            <div style="text-align:center; margin-top:16px;">
+                <button class="btn" onclick="closePasswordPad()">Cancel</button>
+                <button class="btn" onclick="verifyPassword()">Submit</button>
             </div>
-            
-            <div class="pin-keypad">
-                <button class="pin-key" onclick="addPinDigit(1)">1</button>
-                <button class="pin-key" onclick="addPinDigit(2)">2</button>
-                <button class="pin-key" onclick="addPinDigit(3)">3</button>
-                <button class="pin-key" onclick="addPinDigit(4)">4</button>
-                <button class="pin-key" onclick="addPinDigit(5)">5</button>
-                <button class="pin-key" onclick="addPinDigit(6)">6</button>
-                <button class="pin-key" onclick="addPinDigit(7)">7</button>
-                <button class="pin-key" onclick="addPinDigit(8)">8</button>
-                <button class="pin-key" onclick="addPinDigit(9)">9</button>
-                <button class="pin-key special-clear" onclick="clearPin()">Clear</button>
-                <button class="pin-key" onclick="addPinDigit(0)">0</button>
-                <button class="pin-key special-cancel" onclick="closePinPad()">Cancel</button>
-            </div>
-            
         </div>
     </div>
 
@@ -1435,11 +1324,11 @@
         const XANO_CACHE_URL = 'https://xvkq-pq7i-idtl.n7d.xano.io/api:Hj4C6PGO/ikey_cache';
         const ARCHIVE_BASE_URL = 'https://archive.org/download/zuboff';
         const AUTO_LOGOUT_MS = 45 * 60 * 1000;
-        let pinEntry = '';
+        let passwordEntry = '';
 
         const state = {
             currentGUID: null,
-            pinUnlocked: false,
+            passwordUnlocked: false,
             isFirstTime: false,
             isShareMode: false,
             autoSaveTimer: null,
@@ -1453,7 +1342,7 @@
                 lastSyncResults: {}
             },
 
-            pinAttemptsRemaining: 5,
+            passwordAttemptsRemaining: 5,
 
             publicData: {
                 emergency: {}
@@ -1464,56 +1353,58 @@
             }
         };
 
-        function promptForPIN() {
+        function promptForPassword() {
             return new Promise((resolve, reject) => {
-                window.pinPromiseResolve = resolve;
-                window.pinPromiseReject = reject;
-                pinAction = 'prompt';
-                pinCallback = null;
-                document.getElementById('pin-modal').classList.add('active');
-                document.getElementById('pin-modal-title').textContent = 'Enter 6-Digit PIN';
-                pinEntry = '';
-                updatePinDisplay();
+                window.passwordPromiseResolve = resolve;
+                window.passwordPromiseReject = reject;
+                passwordAction = 'prompt';
+                passwordCallback = null;
+                document.getElementById('password-modal').classList.add('active');
+                document.getElementById('password-modal-title').textContent = 'Enter Password';
+                passwordEntry = '';
+                const input = document.getElementById('password-input');
+                input.value = '';
+                setTimeout(() => input.focus(), 0);
             });
         }
 
         // Zero-knowledge utilities
-        async function decryptWithPIN(callback) {
-            let pin = await promptForPIN();
-            if (!pin) return null;
+        async function decryptWithPassword(callback) {
+            let password = await promptForPassword();
+            if (!password) return null;
             try {
-                const pinKey = await deriveKeyFromPIN(pin);
-                const result = await callback(pinKey);
-                crypto.getRandomValues(pinKey);
+                const passwordKey = await deriveKeyFromPassword(password);
+                const result = await callback(passwordKey);
+                crypto.getRandomValues(passwordKey);
                 return result;
             } finally {
-                pin = null;
+                password = null;
             }
         }
 
         async function loadProtectedData() {
-            return decryptWithPIN(async (pinKey) => {
+            return decryptWithPassword(async (passwordKey) => {
                 const stored = localStorage.getItem(`ikey_${state.currentGUID}_protected`);
                 if (!stored) return null;
                 try {
-                    const decrypted = await decrypt(stored, pinKey);
+                    const decrypted = await decrypt(stored, passwordKey);
                     state.protectedData = decrypted;
-                    state.pinUnlocked = true;
+                    state.passwordUnlocked = true;
                     return true;
                 } catch (e) {
-                    state.pinUnlocked = false;
-                    throw new Error('Invalid PIN');
+                    state.passwordUnlocked = false;
+                    throw new Error('Invalid password');
                 }
             });
         }
 
         async function saveProtectedData() {
-            if (!state.pinUnlocked) {
+            if (!state.passwordUnlocked) {
                 showStatus('Protected data not unlocked', 'error');
                 return;
             }
-            return decryptWithPIN(async (pinKey) => {
-                const encrypted = await encrypt(state.protectedData, pinKey);
+            return decryptWithPassword(async (passwordKey) => {
+                const encrypted = await encrypt(state.protectedData, passwordKey);
                 localStorage.setItem(`ikey_${state.currentGUID}_protected`, encrypted);
             });
         }
@@ -1525,18 +1416,18 @@
                 this.sessionKey = null;
             }
 
-            async unlock(pin) {
-                const pinHash = await hashPIN(pin);
-                const storedHash = localStorage.getItem(`ikey_pin_hash_${state.currentGUID}`);
-                if (pinHash !== storedHash) {
-                    throw new Error('Invalid PIN');
+            async unlock(password) {
+                const passwordHash = await hashPassword(password);
+                const storedHash = localStorage.getItem(`ikey_password_hash_${state.currentGUID}`);
+                if (passwordHash !== storedHash) {
+                    throw new Error('Invalid password');
                 }
                 this.sessionKey = crypto.getRandomValues(new Uint8Array(32));
-                const pinKey = await deriveKeyFromPIN(pin);
+                const passwordKey = await deriveKeyFromPassword(password);
                 const stored = localStorage.getItem(`ikey_${state.currentGUID}_protected`);
-                const decrypted = await decrypt(stored, pinKey);
+                const decrypted = await decrypt(stored, passwordKey);
                 this.protectedCache = await encrypt(decrypted, this.sessionKey);
-                crypto.getRandomValues(pinKey);
+                crypto.getRandomValues(passwordKey);
                 this.resetTimer();
                 return true;
             }
@@ -1566,26 +1457,26 @@
 
         const session = new SessionUnlock();
 
-        async function unlockWithPIN() {
-            const pin = await promptForPIN();
+        async function unlockWithPassword() {
+            const password = await promptForPassword();
             try {
-                await session.unlock(pin);
-                state.pinUnlocked = true;
+                await session.unlock(password);
+                state.passwordUnlocked = true;
                 updateUI();
             } catch (e) {
-                showStatus('Invalid PIN', 'error');
+                showStatus('Invalid password', 'error');
             }
         }
 
         async function accessProtectedData() {
-            if (!state.pinUnlocked) {
-                await unlockWithPIN();
+            if (!state.passwordUnlocked) {
+                await unlockWithPassword();
             }
             try {
                 return await session.getProtectedData();
             } catch (e) {
-                state.pinUnlocked = false;
-                await unlockWithPIN();
+                state.passwordUnlocked = false;
+                await unlockWithPassword();
                 return await session.getProtectedData();
             }
         }
@@ -1634,7 +1525,7 @@
 
             applyThemeSpecifics(theme) {
                 const lock = document.getElementById('lockText');
-                if (lock) lock.textContent = 'PIN Protected';
+                if (lock) lock.textContent = 'Password Protected';
                 if (theme === 'topsecret') {
                     document.querySelectorAll('.timestamp').forEach(el => {
                         const date = new Date(el.textContent);
@@ -1646,7 +1537,7 @@
                     });
                     if (lock) lock.textContent = 'CLEARANCE LEVEL: PUBLIC';
                     document.querySelectorAll('.security-badge').forEach(badge => {
-                        badge.textContent = badge.textContent.replace('PIN Protected', 'LEVEL 2 CLEARANCE');
+                        badge.textContent = badge.textContent.replace('Password Protected', 'LEVEL 2 CLEARANCE');
                     });
                 }
             },
@@ -1761,7 +1652,7 @@
                     localStorage.removeItem(`ikey_${savedGUID}_public`);
                     localStorage.removeItem(`ikey_${savedGUID}_protected`);
                     localStorage.removeItem(`ikey_hash_${savedGUID}`);
-                    localStorage.removeItem(`ikey_pin_temp_${savedGUID}`);
+                    localStorage.removeItem(`ikey_password_temp_${savedGUID}`);
                     state.isFirstTime = true;
                     showSetupWizard();
                 }
@@ -1772,7 +1663,6 @@
             }
 
             // Setup keyboard listeners and activity tracking
-            setupKeyboardListeners();
             ['mousemove', 'keypress', 'click', 'touchstart', 'scroll'].forEach(evt => {
                 document.addEventListener(evt, trackActivity, { passive: true });
             });
@@ -1808,7 +1698,7 @@
         function createNewInstance() {
             if (confirm('Create a new medical profile? Current data will be preserved.')) {
                 state.currentGUID = null;
-                state.pinUnlocked = false;
+                state.passwordUnlocked = false;
                 window.location.hash = '';
                 showSetupWizard();
             }
@@ -1822,46 +1712,14 @@
                     localStorage.removeItem(`ikey_${state.currentGUID}_public`);
                     localStorage.removeItem(`ikey_${state.currentGUID}_protected`);
                     localStorage.removeItem(`ikey_hash_${state.currentGUID}`);
-                    localStorage.removeItem(`ikey_pin_temp_${state.currentGUID}`);
+                    localStorage.removeItem(`ikey_password_temp_${state.currentGUID}`);
                     window.location.hash = '';
                     location.reload();
                 }
             }
         }
 
-        // Keyboard Support for PIN Entry
-        function setupKeyboardListeners() {
-            document.addEventListener('keydown', function(e) {
-                // Handle keyboard only when PIN modal is active
-                const pinModal = document.getElementById('pin-modal');
-
-                if (pinModal.classList.contains('active')) {
-                    // Handle number keys 0-9
-                    if (e.key >= '0' && e.key <= '9') {
-                        e.preventDefault();
-                        const digit = parseInt(e.key);
-                        addPinDigit(digit);
-                    }
-                    // Handle backspace/delete
-                    else if (e.key === 'Backspace' || e.key === 'Delete') {
-                        e.preventDefault();
-                        clearPin();
-                    }
-                    // Handle Enter
-                    else if (e.key === 'Enter') {
-                        e.preventDefault();
-                        if (pinEntry.length === 6) {
-                            verifyPIN();
-                        }
-                    }
-                    // Handle Escape
-                    else if (e.key === 'Escape') {
-                        e.preventDefault();
-                        closePinPad();
-                    }
-                }
-            });
-        }
+        // Keyboard input handled by native password field
 
         function trackActivity() {
             state.lastActivity = Date.now();
@@ -1886,10 +1744,10 @@
         }
 
         function autoLogout() {
-            state.pinUnlocked = false;
-            pinEntry = '';
-            localStorage.removeItem(`ikey_pin_temp_${state.currentGUID}`);
-            localStorage.removeItem(`ikey_pin_hash_${state.currentGUID}`);
+            state.passwordUnlocked = false;
+            passwordEntry = '';
+            localStorage.removeItem(`ikey_password_temp_${state.currentGUID}`);
+            localStorage.removeItem(`ikey_password_hash_${state.currentGUID}`);
             updateSecurityUI();
             showStatus('Session expired for security', 'warning');
             showTab('emergency');
@@ -1981,9 +1839,9 @@
                 }
             }
             if (step === 3) {
-                const pin = document.getElementById('setup-pin').value;
-                if (!pin || pin.length !== 6) {
-                    alert('Please enter a 6-digit PIN');
+                const password = document.getElementById('setup-password').value;
+                if (!password || password.length !== 6) {
+                    alert('Please enter a password');
                     return false;
                 }
             }
@@ -2042,12 +1900,12 @@
                     contactOther: document.getElementById('setup-contact-other').value
                 };
                 
-                const pin = document.getElementById('setup-pin').value;
+                const password = document.getElementById('setup-password').value;
 
-                if (pin && pin.length === 6) {
-                    const pinHash = await hashPIN(pin);
-                    localStorage.setItem(`ikey_pin_hash_${state.currentGUID}`, pinHash);
-                    state.pinUnlocked = true;
+                if (password && password.length === 6) {
+                    const passwordHash = await hashPassword(password);
+                    localStorage.setItem(`ikey_password_hash_${state.currentGUID}`, passwordHash);
+                    state.passwordUnlocked = true;
                 }
 
                 // Update message
@@ -2196,13 +2054,13 @@
             return crypto.getRandomValues(new Uint8Array(32));
         }
 
-        async function deriveKeyFromPIN(pin) {
+        async function deriveKeyFromPassword(password) {
             const encoder = new TextEncoder();
-            const pinData = encoder.encode(pin + state.currentGUID);
-            
+            const passwordData = encoder.encode(password + state.currentGUID);
+
             const keyMaterial = await crypto.subtle.importKey(
                 'raw',
-                pinData,
+                passwordData,
                 { name: 'PBKDF2' },
                 false,
                 ['deriveBits']
@@ -2222,14 +2080,14 @@
             return new Uint8Array(derivedBits);
         }
 
-        async function hashPIN(pin) {
+        async function hashPassword(password) {
             const encoder = new TextEncoder();
-            const hash = await crypto.subtle.digest('SHA-256', encoder.encode(pin));
+            const hash = await crypto.subtle.digest('SHA-256', encoder.encode(password));
             return btoa(String.fromCharCode(...new Uint8Array(hash)));
         }
 
-        async function generateDoubleHash(baseKey, pin, salt = '') {
-            const combined = btoa(String.fromCharCode(...baseKey)) + pin + salt;
+        async function generateDoubleHash(baseKey, password, salt = '') {
+            const combined = btoa(String.fromCharCode(...baseKey)) + password + salt;
             const encoder = new TextEncoder();
             const firstHash = await crypto.subtle.digest('SHA-256', encoder.encode(combined));
             const secondHash = await crypto.subtle.digest('SHA-256', firstHash);
@@ -2273,9 +2131,9 @@
             state.baseKey = await generateKey();
             localStorage.setItem(`ikey_basekey_${state.currentGUID}`,
                 btoa(String.fromCharCode(...state.baseKey)));
-            const storedPin = localStorage.getItem(`ikey_pin_temp_${state.currentGUID}`) || '';
-            if (storedPin) {
-                state.currentDoubleHash = await generateDoubleHash(state.baseKey, storedPin);
+            const storedPassword = localStorage.getItem(`ikey_password_temp_${state.currentGUID}`) || '';
+            if (storedPassword) {
+                state.currentDoubleHash = await generateDoubleHash(state.baseKey, storedPassword);
                 const encryptedHash = await encrypt({ hash: state.currentDoubleHash }, state.baseKey);
                 localStorage.setItem(`ikey_hash_${state.currentGUID}`, encryptedHash);
             }
@@ -2402,7 +2260,7 @@
 
         async function saveAllData() {
             await savePublicData();
-            if (state.pinUnlocked) await saveProtectedData();
+            if (state.passwordUnlocked) await saveProtectedData();
         }
 
         // Unified save with feedback
@@ -2546,25 +2404,27 @@
             `;
         }
 
-        // PIN Management
-        let pinAction = null;
-        let pinCallback = null;
+        // Password Management
+        let passwordAction = null;
+        let passwordCallback = null;
 
-        function requestPINForSetup() {
-            pinAction = 'setup';
-            pinCallback = null;
-            document.getElementById('pin-modal').classList.add('active');
-            document.getElementById('pin-modal-title').textContent = 'Set Your 6-Digit PIN';
-            pinEntry = '';
-            updatePinDisplay();
+        function requestPasswordForSetup() {
+            passwordAction = 'setup';
+            passwordCallback = null;
+            document.getElementById('password-modal').classList.add('active');
+            document.getElementById('password-modal-title').textContent = 'Set Your Password';
+            passwordEntry = '';
+            const input = document.getElementById('password-input');
+            input.value = '';
+            setTimeout(() => input.focus(), 0);
         }
 
-        function requestPIN(action = 'unlock', callback = null) {
+        function requestPassword(action = 'unlock', callback = null) {
             if (typeof action === 'function') {
                 callback = action;
                 action = 'unlock';
             }
-            if (state.pinUnlocked && action !== 'change' && action !== 'setup') {
+            if (state.passwordUnlocked && action !== 'change' && action !== 'setup') {
                 if (action === 'edit') {
                     editEmergencyInfo();
                 } else if (callback) {
@@ -2573,136 +2433,114 @@
                 return;
             }
 
-            pinAction = action;
-            pinCallback = callback;
-            document.getElementById('pin-modal').classList.add('active');
-            document.getElementById('pin-modal-title').textContent = action === 'setup'
-                ? 'Set 6-Digit PIN'
-                : 'Enter 6-Digit PIN';
-            pinEntry = '';
-            updatePinDisplay();
+            passwordAction = action;
+            passwordCallback = callback;
+            document.getElementById('password-modal').classList.add('active');
+            document.getElementById('password-modal-title').textContent = action === 'setup'
+                ? 'Set Password'
+                : 'Enter Password';
+            passwordEntry = '';
+            const input = document.getElementById('password-input');
+            input.value = '';
+            setTimeout(() => input.focus(), 0);
         }
 
-        function addPinDigit(digit) {
-            if (pinEntry.length < 6) {
-                pinEntry += digit;
-                updatePinDisplay();
-
-                if (pinEntry.length === 6) {
-                    setTimeout(verifyPIN, 100);
-                }
-            }
-        }
-
-        function clearPin() {
-            pinEntry = '';
-            updatePinDisplay();
-        }
-
-        function closePinPad() {
-            document.getElementById('pin-modal').classList.remove('active');
-            pinEntry = '';
-            pinAction = null;
-            pinCallback = null;
+        function closePasswordPad() {
+            document.getElementById('password-modal').classList.remove('active');
+            passwordEntry = '';
+            passwordAction = null;
+            passwordCallback = null;
             // Only reject if a promise was waiting (actual cancel)
-            if (window.pinPromiseReject) {
-                window.pinPromiseReject(new Error('PIN entry cancelled'));
-                window.pinPromiseResolve = null;
-                window.pinPromiseReject = null;
+            if (window.passwordPromiseReject) {
+                window.passwordPromiseReject(new Error('Password entry cancelled'));
+                window.passwordPromiseResolve = null;
+                window.passwordPromiseReject = null;
             }
         }
 
-        function updatePinDisplay() {
-            const dots = document.querySelectorAll('#pinDisplay .pin-dot');
-            dots.forEach((dot, index) => {
-                dot.classList.toggle('filled', index < pinEntry.length);
-                dot.classList.remove('error');
-            });
-        }
-
-        async function verifyPIN() {
+        async function verifyPassword() {
             // Handle setup flow
-            if (pinAction === 'setup') {
-                document.getElementById('setup-pin').value = pinEntry;
-                document.getElementById('setup-pin-display').style.display = 'block';
-                closePinPad();
+            passwordEntry = document.getElementById('password-input').value;
+            if (passwordAction === 'setup') {
+                document.getElementById('setup-password').value = passwordEntry;
+                document.getElementById('setup-password-display').style.display = 'block';
+                closePasswordPad();
                 return;
             }
 
-            // Handle promise-based PIN entry (zero-knowledge functions)
-            if (window.pinPromiseResolve) {
-                if (pinEntry.length === 6) {
-                    const tempPin = pinEntry;
-                    const resolver = window.pinPromiseResolve;
-                    window.pinPromiseResolve = null;
-                    window.pinPromiseReject = null;
-                    closePinPad();
-                    resolver(tempPin);
+            // Handle promise-based entry (zero-knowledge functions)
+            if (window.passwordPromiseResolve) {
+                if (passwordEntry.length > 0) {
+                    const tempPassword = passwordEntry;
+                    const resolver = window.passwordPromiseResolve;
+                    window.passwordPromiseResolve = null;
+                    window.passwordPromiseReject = null;
+                    closePasswordPad();
+                    resolver(tempPassword);
                     return;
                 }
             }
 
             // Standard verification
             try {
-                const pinHash = await hashPIN(pinEntry);
-                const storedHash = localStorage.getItem(`ikey_pin_hash_${state.currentGUID}`);
+                const passwordHash = await hashPassword(passwordEntry);
+                const storedHash = localStorage.getItem(`ikey_password_hash_${state.currentGUID}`);
 
-                if (pinHash === storedHash) {
-                    state.pinUnlocked = true;
+                if (passwordHash === storedHash) {
+                    state.passwordUnlocked = true;
 
                     if (typeof session !== 'undefined' && session.unlock) {
-                        await session.unlock(pinEntry);
+                        await session.unlock(passwordEntry);
                     }
 
-                    if (window.pinPromiseResolve) {
-                        const resolver = window.pinPromiseResolve;
-                        window.pinPromiseResolve = null;
-                        window.pinPromiseReject = null;
-                        closePinPad();
-                        resolver(pinEntry);
+                    if (window.passwordPromiseResolve) {
+                        const resolver = window.passwordPromiseResolve;
+                        window.passwordPromiseResolve = null;
+                        window.passwordPromiseReject = null;
+                        closePasswordPad();
+                        resolver(passwordEntry);
                         return;
                     }
 
-                    closePinPad();
-                    state.pinAttemptsRemaining = 5;
+                    closePasswordPad();
+                    state.passwordAttemptsRemaining = 5;
 
-                    if (pinAction === 'edit') {
+                    if (passwordAction === 'edit') {
                         editEmergencyInfo();
-                    } else if (pinAction === 'unlock') {
-                        unlockPINLevel();
-                        showStatus('PIN verified successfully', 'success');
-                    } else if (pinAction === 'change') {
-                        showStatus('PIN changed successfully', 'success');
+                    } else if (passwordAction === 'unlock') {
+                        unlockPasswordLevel();
+                        showStatus('Password verified successfully', 'success');
+                    } else if (passwordAction === 'change') {
+                        showStatus('Password changed successfully', 'success');
                     }
 
-                    if (typeof pinCallback === 'function') {
-                        pinCallback();
+                    if (typeof passwordCallback === 'function') {
+                        passwordCallback();
                     }
 
                 } else {
-                    throw new Error('Invalid PIN');
+                    throw new Error('Invalid password');
                 }
 
             } catch (error) {
-                state.pinAttemptsRemaining--;
-                showStatus(`Wrong PIN. ${state.pinAttemptsRemaining} attempts remaining`, 'error');
-                document.querySelectorAll('#pinDisplay .pin-dot').forEach(dot => dot.classList.add('error'));
+                state.passwordAttemptsRemaining--;
+                showStatus(`Wrong password. ${state.passwordAttemptsRemaining} attempts remaining`, 'error');
                 setTimeout(() => {
-                    pinEntry = '';
-                    updatePinDisplay();
+                    passwordEntry = '';
+                    document.getElementById('password-input').value = '';
                 }, 1000);
 
-                if (state.pinAttemptsRemaining <= 0 && window.pinPromiseReject) {
-                    const rejector = window.pinPromiseReject;
-                    window.pinPromiseResolve = null;
-                    window.pinPromiseReject = null;
-                    closePinPad();
+                if (state.passwordAttemptsRemaining <= 0 && window.passwordPromiseReject) {
+                    const rejector = window.passwordPromiseReject;
+                    window.passwordPromiseResolve = null;
+                    window.passwordPromiseReject = null;
+                    closePasswordPad();
                     rejector(new Error('Too many incorrect attempts'));
                 }
             }
         }
 
-        function unlockPINLevel() {
+        function unlockPasswordLevel() {
             updateSecurityUI();
         }
 
@@ -2858,8 +2696,8 @@
 
         // Tab Navigation
         function showTab(tabName) {
-            if (!state.pinUnlocked && (tabName === 'health' || tabName === 'security')) {
-                requestPIN('unlock', () => showTab(tabName));
+            if (!state.passwordUnlocked && (tabName === 'health' || tabName === 'security')) {
+                requestPassword('unlock', () => showTab(tabName));
                 return;
             }
 
@@ -2906,10 +2744,10 @@
         }
 
         function updateSecurityUI() {
-            if (state.pinUnlocked) {
+            if (state.passwordUnlocked) {
                 document.getElementById('lockIcon').textContent = '🔐';
-                document.getElementById('lockText').textContent = 'PIN Protected';
-                document.getElementById('securityBadge').className = 'security-badge badge-pin';
+                document.getElementById('lockText').textContent = 'Password Protected';
+                document.getElementById('securityBadge').className = 'security-badge badge-password';
                 document.getElementById('healthTab').classList.remove('locked');
                 document.getElementById('securityTab').classList.remove('locked');
             } else {
@@ -2928,7 +2766,7 @@
                 guid: state.currentGUID,
                 timestamp: new Date().toISOString(),
                 publicData: state.publicData,
-                protectedData: state.pinUnlocked ? state.protectedData : null
+                protectedData: state.passwordUnlocked ? state.protectedData : null
             };
             
             const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
@@ -2983,7 +2821,7 @@
             const indicator = document.getElementById('security-indicator');
             if (!indicator) return;
 
-            if (state.pinUnlocked) {
+            if (state.passwordUnlocked) {
                 indicator.innerHTML = `
             <span style="color: #10B981;">🔓 Unlocked</span>
             <button onclick="lockApp()" style="padding: 2px 6px; background: #EF4444; color: white; border: none; border-radius: 4px; font-size: 0.75rem;">Lock</button>
@@ -2997,7 +2835,7 @@
         }
 
         function lockApp() {
-            state.pinUnlocked = false;
+            state.passwordUnlocked = false;
             session.lock();
             updateSecurityIndicator();
             updateSecurityUI();
@@ -3055,11 +2893,11 @@
         });
 
         window.addEventListener('beforeunload', function() {
-            pinEntry = '';
+            passwordEntry = '';
             session.lock();
-            localStorage.removeItem(`ikey_pin_temp_${state.currentGUID}`);
+            localStorage.removeItem(`ikey_password_temp_${state.currentGUID}`);
             if (state.currentGUID) {
-                localStorage.removeItem(`ikey_pin_hash_${state.currentGUID}`);
+                localStorage.removeItem(`ikey_password_hash_${state.currentGUID}`);
             }
             sessionStorage.removeItem('ikey_session_active');
         });


### PR DESCRIPTION
## Summary
- Replace keypad PIN entry with a password modal and input field
- Rename all PIN helpers to password equivalents and update storage keys
- Hash and verify passwords with updated functions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ce96c6f08332bbc31e8730ec1b7a