### PR TITLE
Use single password and auto-generate QR code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ iKey Health is a client-side encrypted, progressive web application for storing 
 
 ### Three-Tier Security Model
 
-The system implements a progressive disclosure model with three security levels:
+The system implements a progressive disclosure model with two security levels:
 
 1. **Public Tier (Emergency Information)**
    - Accessible via QR code without authentication
@@ -16,16 +16,10 @@ The system implements a progressive disclosure model with three security levels:
    - Encrypted with a base key embedded in the QR code
    - Designed for first responders in emergency situations
 
-2. **PIN-Protected Tier (Health Records)**
-   - Requires 6-digit PIN authentication
-   - Contains medical history, surgeries, family history, health notes
-   - PIN serves as encryption key derivation source (PBKDF2, 100,000 iterations)
-
-3. **Password-Protected Tier (Full EHR)**
-   - Requires strong password (8+ characters)
-   - Contains comprehensive electronic health records
-   - Includes provider management, detailed medications, conditions tracking, case notes
-   - Password derives strongest encryption key (PBKDF2, 200,000 iterations)
+2. **Password-Protected Tier (Health Records)**
+   - Requires a strong password for access
+   - Contains medical history, surgeries, family history, health notes, and detailed records
+   - Password serves as the encryption key derivation source (PBKDF2, 100,000 iterations)
 
 ## Security Implementation
 
@@ -36,14 +30,13 @@ User Data → JSON → AES-256-GCM Encryption → Base64 → localStorage
                         ↑
                     Derived Key
                         ↑
-                PIN/Password + GUID + Salt → PBKDF2
+                Password + GUID + Salt → PBKDF2
 ```
 
 - **Key Derivation**: Uses Web Crypto API's PBKDF2 with SHA-256
 - **Encryption**: AES-256-GCM with random 12-byte IV per encryption
 - **Key Hierarchy**:
   - Base Key: Random 32-byte key for emergency data
-  - PIN Key: Derived from 6-digit PIN + GUID
   - Password Key: Derived from password + GUID + "secure" salt
 
 ### Client-Side Security Features
@@ -51,8 +44,8 @@ User Data → JSON → AES-256-GCM Encryption → Base64 → localStorage
 - All encryption/decryption happens in-browser
 - No plaintext data transmitted to servers
 - Keys never leave the client
-- PIN and password ARE the encryption keys (not just authentication)
- - Cannot recover forgotten PIN/password
+- Password is the encryption key (not just authentication)
+- Cannot recover forgotten password
 
 ## Data Storage
 
@@ -224,17 +217,15 @@ https://example.com/ikey.html#a1b2c3d4-e5f6-7890-abcd-ef1234567890:SGVsbG9Xb3JsZ
 
 ## Recovery Mechanisms
 
-A recovery key file provides an alternate login path if your PIN or password is lost. The key file is automatically downloaded during setup and whenever you change your PIN or EHR password. It is encrypted using the application's base URL—store it securely as a new key file is required after each credential change.
+A recovery key file provides an alternate login path if your password is lost. The key file is automatically downloaded during setup and whenever you change your password. It is encrypted using the application's base URL—store it securely as a new key file is required after each credential change.
 
 ## User Experience Features
 
 ### Keyboard Support
 
-PIN entry supports full keyboard interaction:
-- **Number keys (0-9)**: Enter PIN digits
-- **Backspace/Delete**: Clear current entry
-- **Enter**: Confirm when 6 digits entered
-- **Escape**: Cancel PIN entry
+Password entry supports full keyboard interaction:
+- **Enter**: Submit password
+- **Escape**: Cancel entry
 - **Tab navigation**: Accessible interface
 
 ### Auto-Save System
@@ -250,13 +241,11 @@ Input Change → 2s Debounce → Encrypt → Save to localStorage → Sync to Cl
 
 ### Progressive Disclosure
 
-1. **Initial Setup**: Minimal (name + emergency info + PIN)
-2. **Health Records**: Unlock with PIN when needed
-3. **Full EHR**: Add password for comprehensive records
-4. **Visual Security Indicators**:
+1. **Initial Setup**: Minimal (name + emergency info + password)
+2. **Health Records**: Unlock with password when needed
+3. **Visual Security Indicators**:
    - 🔓 Public Access (gray badge)
-   - 🔐 PIN Protected (blue badge)
-   - 🔒 Fully Secured (purple badge)
+   - 🔐 Password Protected (blue badge)
 
 ## Archive.org Integration Strategy
 
@@ -289,7 +278,7 @@ async function archiveToWayback(data) {
 - **Defense in depth**: Multiple encryption tiers
 - **Client-side encryption**: Uses modern Web Crypto API
 - **No account system**: Reduces attack surface
-- **Deterministic key derivation**: PIN/password reproducibly generate same keys
+- **Deterministic key derivation**: Password reproducibly generates the same keys
 - **Forward secrecy**: Each encryption uses new IV
 
 ### Limitations
@@ -305,7 +294,7 @@ async function archiveToWayback(data) {
 | Threat | Mitigation |
 |--------|------------|
 | Server compromise | Client-side encryption, zero-knowledge |
-| Device theft | PIN/password protection |
+| Device theft | Password protection |
 | XSS attacks | Content Security Policy, input sanitization |
 | Network interception | HTTPS only, encrypted payloads |
 | Brute force | PBKDF2 high iterations, rate limiting |
@@ -315,12 +304,12 @@ async function archiveToWayback(data) {
 
 When working with this codebase:
 
-1. **Never log sensitive data**: PINs, passwords, or decrypted medical information
+1. **Never log sensitive data**: passwords or decrypted medical information
 2. **Maintain encryption boundaries**: Don't decrypt unnecessarily
 3. **Respect security tiers**: Each tier has specific access requirements
 4. **Handle crypto errors gracefully**: Invalid keys should fail safely
 5. **Preserve client-side nature**: Avoid server dependencies for core functionality
-6. **Test edge cases**: Wrong PIN, corrupted data, browser storage limits
+6. **Test edge cases**: Wrong password, corrupted data, browser storage limits
 7. **Consider offline-first**: Should work without network connection
 8. **Validate all inputs**: Especially before encryption operations
 

--- a/index.html
+++ b/index.html
@@ -1107,13 +1107,13 @@
                     <div class="info-card">
                         <span class="info-card-icon">📝</span>
                         <div class="info-card-content">
-                            <div class="info-card-label">Level 2: Demographics (PIN)</div>
-                            <div class="info-card-value">Contact info and basic details - protected by 6-digit PIN</div>
+                            <div class="info-card-label">Level 2: Demographics (Password)</div>
+                            <div class="info-card-value">Contact info and basic details - protected by your password</div>
                         </div>
                     </div>
 
                     <div class="warning-box">
-                        <strong>Important:</strong> Your PIN IS your encryption key. It cannot be recovered if lost. Store it safely.
+                        <strong>Important:</strong> Your password IS your encryption key. It cannot be recovered if lost. Store it safely.
                     </div>
                 </div>
                 
@@ -1340,7 +1340,7 @@
             </div>
             <div id="emergency-display"></div>
             <div class="btn-group mt-4">
-                <button class="btn" onclick="requestPIN('edit')">
+                <button class="btn" onclick="requestPassword('edit')">
                     🔐 Edit Information
                 </button>
                 <button class="btn btn-outline" onclick="generateMainQR()">
@@ -1357,7 +1357,7 @@
             </div>
         </div>
 
-        <!-- Health Section (PIN Tier) -->
+        <!-- Health Section (Password Tier) -->
         <div class="content-section" id="health-section">
             <div class="section-header">
                 <h2>Health Information</h2>
@@ -1389,16 +1389,16 @@
             
         </div>
 
-        <!-- Security Section (PIN Tier) -->
+        <!-- Security Section -->
         <div class="content-section" id="security-section">
             <div class="section-header">
                 <h2>Security & Settings</h2>
             </div>
             
             <div class="mb-4">
-                <h3>PIN Management</h3>
+                <h3>Password Management</h3>
                 <p style="color: var(--text-secondary); margin-top: 8px; font-size: 0.875rem;">
-                    Set and manage your PIN for accessing protected health data.
+                    Set and manage your password for accessing protected health data.
                 </p>
             </div>
             
@@ -1417,7 +1417,7 @@
 
     </div>
 
-    <!-- PIN Modal -->
+    <!-- Password Modal -->
     <div id="pin-modal" class="modal-overlay">
         <div class="modal-container">
             <h3 class="modal-title" id="pin-modal-title">Enter Password</h3>
@@ -1456,7 +1456,6 @@
         const AUTO_LOGOUT_MS = 45 * 60 * 1000;
         const MAX_ATTEMPTS = 5;
         const LOCKOUT_DURATION = 15 * 60 * 1000;
-        let pinEntry = '';
 
         const state = {
             currentGUID: null,
@@ -1483,35 +1482,35 @@
             }
         };
 
-        function promptForPIN() {
+        function promptForPassword() {
             return new Promise((resolve, reject) => {
                 window.pinPromiseResolve = resolve;
                 window.pinPromiseReject = reject;
                 pinAction = 'prompt';
                 pinCallback = null;
-                document.getElementById('pin-modal').classList.add('active');
-                document.getElementById('pin-modal-title').textContent = 'Enter 6-Digit PIN';
-                pinEntry = '';
-                updatePinDisplay();
+                const modal = document.getElementById('pin-modal');
+                modal.classList.add('active');
+                document.getElementById('pin-modal-title').textContent = 'Enter Password';
+                document.getElementById('passwordInput').value = '';
             });
         }
 
         // Zero-knowledge utilities
-        async function decryptWithPIN(callback) {
-            let pin = await promptForPIN();
-            if (!pin) return null;
+        async function decryptWithPassword(callback) {
+            let password = await promptForPassword();
+            if (!password) return null;
             try {
-                const pinKey = await deriveKeyFromPassword(pin);
+                const pinKey = await deriveKeyFromPassword(password);
                 const result = await callback(pinKey);
                 crypto.getRandomValues(pinKey);
                 return result;
             } finally {
-                pin = null;
+                password = null;
             }
         }
 
         async function loadProtectedData() {
-            return decryptWithPIN(async (pinKey) => {
+            return decryptWithPassword(async (pinKey) => {
                 const stored = localStorage.getItem(`ikey_${state.currentGUID}_protected`);
                 if (!stored) return null;
                 try {
@@ -1521,7 +1520,7 @@
                     return true;
                 } catch (e) {
                     state.pinUnlocked = false;
-                    throw new Error('Invalid PIN');
+                    throw new Error('Invalid password');
                 }
             });
         }
@@ -1531,7 +1530,7 @@
                 showStatus('Protected data not unlocked', 'error');
                 return;
             }
-            return decryptWithPIN(async (pinKey) => {
+            return decryptWithPassword(async (pinKey) => {
                 const encrypted = await encrypt(state.protectedData, pinKey);
                 localStorage.setItem(`ikey_${state.currentGUID}_protected`, encrypted);
             });
@@ -1544,14 +1543,14 @@
                 this.sessionKey = null;
             }
 
-            async unlock(pin) {
-                const pinHash = await hashPIN(pin);
+            async unlock(password) {
+                const passwordHash = await hashPassword(password);
                 const storedHash = localStorage.getItem(`ikey_pin_hash_${state.currentGUID}`);
-                if (pinHash !== storedHash) {
-                    throw new Error('Invalid PIN');
+                if (passwordHash !== storedHash) {
+                    throw new Error('Invalid Password');
                 }
                 this.sessionKey = crypto.getRandomValues(new Uint8Array(32));
-                const pinKey = await deriveKeyFromPassword(pin);
+                const pinKey = await deriveKeyFromPassword(password);
                 const stored = localStorage.getItem(`ikey_${state.currentGUID}_protected`);
                 const decrypted = await decrypt(stored, pinKey);
                 this.protectedCache = await encrypt(decrypted, this.sessionKey);
@@ -1585,26 +1584,26 @@
 
         const session = new SessionUnlock();
 
-        async function unlockWithPIN() {
-            const pin = await promptForPIN();
+        async function unlockWithPassword() {
+            const password = await promptForPassword();
             try {
-                await session.unlock(pin);
+                await session.unlock(password);
                 state.pinUnlocked = true;
                 updateUI();
             } catch (e) {
-                showStatus('Invalid PIN', 'error');
+                showStatus('Invalid password', 'error');
             }
         }
 
         async function accessProtectedData() {
             if (!state.pinUnlocked) {
-                await unlockWithPIN();
+                await unlockWithPassword();
             }
             try {
                 return await session.getProtectedData();
             } catch (e) {
                 state.pinUnlocked = false;
-                await unlockWithPIN();
+                await unlockWithPassword();
                 return await session.getProtectedData();
             }
         }
@@ -1653,7 +1652,7 @@
 
             applyThemeSpecifics(theme) {
                 const lock = document.getElementById('lockText');
-                if (lock) lock.textContent = 'PIN Protected';
+                if (lock) lock.textContent = 'Password Protected';
                 if (theme === 'topsecret') {
                     document.querySelectorAll('.timestamp').forEach(el => {
                         const date = new Date(el.textContent);
@@ -1665,7 +1664,7 @@
                     });
                     if (lock) lock.textContent = 'CLEARANCE LEVEL: PUBLIC';
                     document.querySelectorAll('.security-badge').forEach(badge => {
-                        badge.textContent = badge.textContent.replace('PIN Protected', 'LEVEL 2 CLEARANCE');
+                        badge.textContent = badge.textContent.replace('Password Protected', 'LEVEL 2 CLEARANCE');
                     });
                 }
             },
@@ -1848,33 +1847,16 @@
             }
         }
 
-        // Keyboard Support for PIN Entry
+        // Keyboard Support for Password Entry
         function setupKeyboardListeners() {
             document.addEventListener('keydown', function(e) {
-                // Handle keyboard only when PIN modal is active
                 const pinModal = document.getElementById('pin-modal');
 
                 if (pinModal.classList.contains('active')) {
-                    // Handle number keys 0-9
-                    if (e.key >= '0' && e.key <= '9') {
+                    if (e.key === 'Enter') {
                         e.preventDefault();
-                        const digit = parseInt(e.key);
-                        addPinDigit(digit);
-                    }
-                    // Handle backspace/delete
-                    else if (e.key === 'Backspace' || e.key === 'Delete') {
-                        e.preventDefault();
-                        clearPin();
-                    }
-                    // Handle Enter
-                    else if (e.key === 'Enter') {
-                        e.preventDefault();
-                        if (pinEntry.length === 6) {
-                            verifyPIN();
-                        }
-                    }
-                    // Handle Escape
-                    else if (e.key === 'Escape') {
+                        verifyPassword();
+                    } else if (e.key === 'Escape') {
                         e.preventDefault();
                         closePinPad();
                     }
@@ -1906,7 +1888,6 @@
 
         function autoLogout() {
             state.pinUnlocked = false;
-            pinEntry = '';
             localStorage.removeItem(`ikey_pin_temp_${state.currentGUID}`);
             localStorage.removeItem(`ikey_pin_hash_${state.currentGUID}`);
             updateSecurityUI();
@@ -2092,8 +2073,8 @@
                 const password = document.getElementById('setup-password').value;
 
                 if (password) {
-                    const pinHash = await hashPIN(password);
-                    localStorage.setItem(`ikey_pin_hash_${state.currentGUID}`, pinHash);
+                    const passwordHash = await hashPassword(password);
+                    localStorage.setItem(`ikey_pin_hash_${state.currentGUID}`, passwordHash);
                     state.pinUnlocked = true;
                 }
 
@@ -2143,6 +2124,7 @@
                 // Hide wizard and show main app
                 document.getElementById('setup-wizard').classList.add('hidden');
                 await loadExistingUser();
+                generateMainQR();
                 
             } catch (error) {
                 console.error('Setup failed:', error);
@@ -2225,6 +2207,7 @@
 
             await loadPublicData();
             displayEmergencyInfo();
+            generateMainQR();
 
             // Update UI based on what's unlocked
             updateSecurityUI();
@@ -2275,35 +2258,9 @@
             return new Uint8Array(derivedBits);
         }
 
-        async function deriveKeyFromPIN(pin) {
+        async function hashPassword(password) {
             const encoder = new TextEncoder();
-            const pinData = encoder.encode(pin + state.currentGUID);
-            
-            const keyMaterial = await crypto.subtle.importKey(
-                'raw',
-                pinData,
-                { name: 'PBKDF2' },
-                false,
-                ['deriveBits']
-            );
-            
-            const derivedBits = await crypto.subtle.deriveBits(
-                {
-                    name: 'PBKDF2',
-                    salt: encoder.encode(state.currentGUID),
-                    iterations: 100000,
-                    hash: 'SHA-256'
-                },
-                keyMaterial,
-                256
-            );
-            
-            return new Uint8Array(derivedBits);
-        }
-
-        async function hashPIN(pin) {
-            const encoder = new TextEncoder();
-            const hash = await crypto.subtle.digest('SHA-256', encoder.encode(pin));
+            const hash = await crypto.subtle.digest('SHA-256', encoder.encode(password));
             return btoa(String.fromCharCode(...new Uint8Array(hash)));
         }
 
@@ -2625,11 +2582,11 @@
             `;
         }
 
-        // PIN Management
+        // Password Management
         let pinAction = null;
         let pinCallback = null;
 
-        function requestPIN(action = 'unlock', callback = null) {
+        function requestPassword(action = 'unlock', callback = null) {
             if (typeof action === 'function') {
                 callback = action;
                 action = 'unlock';
@@ -2645,49 +2602,23 @@
 
             pinAction = action;
             pinCallback = callback;
-            document.getElementById('pin-modal').classList.add('active');
+            const modal = document.getElementById('pin-modal');
+            modal.classList.add('active');
             document.getElementById('pin-modal-title').textContent = action === 'setup'
-                ? 'Set 6-Digit PIN'
-                : 'Enter 6-Digit PIN';
-            pinEntry = '';
-            updatePinDisplay();
-        }
-
-        function addPinDigit(digit) {
-            if (pinEntry.length < 6) {
-                pinEntry += digit;
-                updatePinDisplay();
-
-                if (pinEntry.length === 6) {
-                    setTimeout(verifyPIN, 100);
-                }
-            }
-        }
-
-        function clearPin() {
-            pinEntry = '';
-            updatePinDisplay();
+                ? 'Set Password'
+                : 'Enter Password';
+            document.getElementById('passwordInput').value = '';
         }
 
         function closePinPad() {
             document.getElementById('pin-modal').classList.remove('active');
-            pinEntry = '';
             pinAction = null;
             pinCallback = null;
-            // Only reject if a promise was waiting (actual cancel)
             if (window.pinPromiseReject) {
-                window.pinPromiseReject(new Error('PIN entry cancelled'));
+                window.pinPromiseReject(new Error('Password entry cancelled'));
                 window.pinPromiseResolve = null;
                 window.pinPromiseReject = null;
             }
-        }
-
-        function updatePinDisplay() {
-            const dots = document.querySelectorAll('#pinDisplay .pin-dot');
-            dots.forEach((dot, index) => {
-                dot.classList.toggle('filled', index < pinEntry.length);
-                dot.classList.remove('error');
-            });
         }
 
         function checkLockout() {
@@ -2726,49 +2657,37 @@
             } else {
                 localStorage.setItem(attemptsKey, attempts.toString());
                 const remaining = MAX_ATTEMPTS - attempts;
-                showStatus(`Wrong PIN. ${remaining} attempts remaining`, 'error');
+                showStatus(`Wrong password. ${remaining} attempts remaining`, 'error');
             }
         }
 
-        async function verifyPIN() {
-            // Handle promise-based PIN entry (zero-knowledge functions)
-            if (window.pinPromiseResolve) {
-                if (pinEntry.length === 6) {
-                    const tempPin = pinEntry;
-                    const resolver = window.pinPromiseResolve;
-                    window.pinPromiseResolve = null;
-                    window.pinPromiseReject = null;
-                    closePinPad();
-                    resolver(tempPin);
-                    return;
-                }
-            }
+        async function verifyPassword() {
+            const inputEl = document.getElementById('passwordInput');
+            const password = inputEl.value;
 
-            if (checkLockout()) {
-                pinEntry = '';
-                updatePinDisplay();
+            if (window.pinPromiseResolve) {
+                const resolver = window.pinPromiseResolve;
+                window.pinPromiseResolve = null;
+                window.pinPromiseReject = null;
+                closePinPad();
+                resolver(password);
                 return;
             }
 
-            // Standard verification
+            if (checkLockout()) {
+                inputEl.value = '';
+                return;
+            }
+
             try {
-                const pinHash = await hashPIN(pinEntry);
+                const passwordHash = await hashPassword(password);
                 const storedHash = localStorage.getItem(`ikey_pin_hash_${state.currentGUID}`);
 
-                if (pinHash === storedHash) {
+                if (passwordHash === storedHash) {
                     state.pinUnlocked = true;
 
                     if (typeof session !== 'undefined' && session.unlock) {
-                        await session.unlock(pinEntry);
-                    }
-
-                    if (window.pinPromiseResolve) {
-                        const resolver = window.pinPromiseResolve;
-                        window.pinPromiseResolve = null;
-                        window.pinPromiseReject = null;
-                        closePinPad();
-                        resolver(pinEntry);
-                        return;
+                        await session.unlock(password);
                     }
 
                     closePinPad();
@@ -2779,10 +2698,10 @@
                     if (pinAction === 'edit') {
                         editEmergencyInfo();
                     } else if (pinAction === 'unlock') {
-                        unlockPINLevel();
-                        showStatus('PIN verified successfully', 'success');
+                        unlockPasswordLevel();
+                        showStatus('Password verified successfully', 'success');
                     } else if (pinAction === 'change') {
-                        showStatus('PIN changed successfully', 'success');
+                        showStatus('Password changed successfully', 'success');
                     }
 
                     if (typeof pinCallback === 'function') {
@@ -2790,16 +2709,12 @@
                     }
 
                 } else {
-                    throw new Error('Invalid PIN');
+                    throw new Error('Invalid password');
                 }
 
             } catch (error) {
                 handleFailedAttempt();
-                document.querySelectorAll('#pinDisplay .pin-dot').forEach(dot => dot.classList.add('error'));
-                setTimeout(() => {
-                    pinEntry = '';
-                    updatePinDisplay();
-                }, 1000);
+                inputEl.value = '';
 
                 const guid = state.currentGUID || 'default';
                 const lockoutUntil = parseInt(localStorage.getItem(`ikey_pin_lockout_${guid}`) || '0', 10);
@@ -2813,7 +2728,7 @@
             }
         }
 
-        function unlockPINLevel() {
+        function unlockPasswordLevel() {
             updateSecurityUI();
         }
 
@@ -2970,7 +2885,7 @@
         // Tab Navigation
         function showTab(tabName) {
             if (!state.pinUnlocked && (tabName === 'health' || tabName === 'security')) {
-                requestPIN('unlock', () => showTab(tabName));
+                requestPassword('unlock', () => showTab(tabName));
                 return;
             }
 
@@ -3019,7 +2934,7 @@
         function updateSecurityUI() {
             if (state.pinUnlocked) {
                 document.getElementById('lockIcon').textContent = '🔐';
-                document.getElementById('lockText').textContent = 'PIN Protected';
+                document.getElementById('lockText').textContent = 'Password Protected';
                 document.getElementById('securityBadge').className = 'security-badge badge-pin';
                 document.getElementById('healthTab').classList.remove('locked');
                 document.getElementById('securityTab').classList.remove('locked');
@@ -3215,7 +3130,6 @@
         });
 
         window.addEventListener('beforeunload', function() {
-            pinEntry = '';
             session.lock();
             localStorage.removeItem(`ikey_pin_temp_${state.currentGUID}`);
             if (state.currentGUID) {


### PR DESCRIPTION
## Summary
- replace PIN-based prompts with password modal and verification
- auto-generate and show QR code after setup and on load
- document new two-tier password-focused security model

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0d35257348332ac4af858faede75f