### PR TITLE
Add imagery for Filen and Proton Mail plus tab icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <title>iKey - Secure Location Hub</title>
-    
+    <link rel="icon" href="https://canada1.discourse-cdn.com/flex035/uploads/techlore/original/2X/7/725fd6b6437d5b2f99b639e36695087965aa9e91.png">
+
     <!-- External Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js"></script>
@@ -1081,8 +1082,11 @@
             <div class="resource-card">
                 <div class="resource-icon">🔐</div>
                 <h2 style="color: var(--primary); margin-bottom: 15px;">Secure Cloud Storage with Filen</h2>
+                <div style="text-align: center; margin-bottom: 20px;">
+                    <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSwL_Iiqw_VgXBMRLJX3IaUhlGQcR4Z7LWnlQ&s" alt="Filen interface" style="max-width: 100%; border-radius: 12px;">
+                </div>
                 <p style="color: var(--secondary); margin-bottom: 25px; line-height: 1.8;">
-                    Store your important documents and emergency files with military-grade encryption. 
+                    Store your important documents and emergency files with military-grade encryption.
                     Filen offers zero-knowledge end-to-end encryption - even they can't see your files.
                 </p>
                 
@@ -1090,7 +1094,7 @@
                     <h3 style="margin-bottom: 12px; color: var(--primary);">🚀 Getting Started</h3>
                     <ol style="line-height: 2; color: var(--secondary); margin-left: 20px;">
                         <li><strong>Create a free account</strong> at Filen.io (10GB free storage)</li>
-                        <li><strong>Need an email?</strong> Get a secure one at <a href="https://proton.me/mail" target="_blank" style="color: var(--primary);">Proton Mail</a></li>
+                        <li><strong>Need an email?</strong> Get a secure one at <a href="https://proton.me/mail" target="_blank" style="color: var(--primary); display: inline-flex; align-items: center; gap: 8px;"><img src="https://sm.pcmag.com/pcmag_uk/review/p/proton-mai/proton-mail_zjn6.jpg" alt="Proton Mail logo" style="width:24px;height:auto;border-radius:4px;">Proton Mail</a></li>
                         <li><strong>Upload your documents</strong> - they're encrypted on your device first</li>
                         <li><strong>Access anywhere</strong> with apps for all platforms</li>
                     </ol>


### PR DESCRIPTION
## Summary
- Display Filen screenshot and Proton Mail logo in storage tab
- Set browser tab icon to provided image

## Testing
- ⚠️ `npm test` (package.json not found)


------
https://chatgpt.com/codex/tasks/task_b_68c0fd6c060c8332b9a09360f8f19324