### PR TITLE
Add Google Translate widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -597,6 +597,7 @@
 <body>
     <!-- Header -->
     <div class="app-header">
+        <div id="google_translate_element" style="position: absolute; top: 10px; right: 10px;"></div>
         <h1>🔐 iKey</h1>
         <p>Secure Location & Personal Safety Hub</p>
     </div>
@@ -1845,5 +1846,19 @@ Generated: ${new Date().toLocaleString()}`;
             }
         });
     </script>
+
+    <script type="text/javascript">
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement(
+                {
+                    pageLanguage: 'en',
+                    includedLanguages: 'es,ar,ckb,so,my',
+                    layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+                },
+                'google_translate_element'
+            );
+        }
+    </script>
+    <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add Google Translate dropdown to header with Nashville's top non-English languages
- Load translation script to enable automatic page translation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0fe2187788332b5f0a2f281ad3f34