### PR TITLE
Remove WTTIN header from embedded resources tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -948,15 +948,9 @@
     <!-- WTTIN Tab -->
     <div id="wttin" class="tab-content">
         <div style="height: calc(100vh - 120px); display: flex; flex-direction: column;">
-            <div style="padding: 20px; background: white; border-bottom: 1px solid var(--border);">
-                <h2 style="margin-bottom: 10px;">Where To Turn in Nashville</h2>
-                <p style="color: var(--secondary);">
-                    Community resources and support services for Nashville residents.
-                </p>
-            </div>
             <div style="flex: 1; position: relative;">
-                <iframe 
-                    src="https://wttin.org" 
+                <iframe
+                    src="https://wttin.org"
                     sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
                     title="WTTIN Resources"
                     loading="lazy"


### PR DESCRIPTION
## Summary
- Remove introductory header and description from the WTTIN tab so only the embedded app is displayed.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0fe546b388332a1dfec007a8118d0