### PR TITLE
Add site favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <title>iKey - Secure Location Hub</title>
-    <link rel="icon" href="https://canada1.discourse-cdn.com/flex035/uploads/techlore/original/2X/7/725fd6b6437d5b2f99b639e36695087965aa9e91.png">
+    <link rel="icon" href="https://storage.googleapis.com/art_homelessness/favicon-32x32.png" type="image/png">
+    <link rel="apple-touch-icon" href="https://storage.googleapis.com/art_homelessness/favicon-32x32.png">
 
     <!-- External Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>


### PR DESCRIPTION
## Summary
- link favicon and apple-touch icon to externally hosted image
- remove local favicon file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1a03ded148332934dab8e4b2d3e8b