### PR TITLE
feat: include Proton email in location copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1473,10 +1473,10 @@ GPS: ${currentLocation.latitude}, ${currentLocation.longitude}
 ADDRESS: ${currentLocation.address}
 INTERSECTION: ${currentLocation.crossStreets}
 PLUS CODE: ${currentLocation.plusCode}
-MAPS: https://maps.google.com/?q=${currentLocation.latitude},${currentLocation.longitude}
+MAPS: https://maps.google.com/?q=${currentLocation.latitude},${currentLocation.longitude}${formData.pe ? `\nPROTON EMAIL: ${formData.pe}` : ''}
 
 Generated: ${new Date().toLocaleString()}`;
-                
+
                 navigator.clipboard.writeText(allInfo)
                     .then(() => alert('All location info copied!'));
             }


### PR DESCRIPTION
## Summary
- add Proton email line to `copyAll()` clipboard output

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1fb17bce08332aeda383ac11597be