### PR TITLE
feat: require pe for wizard steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ state = {
         emergency: {
             name,
             pronouns,
+            pe, // v2: permission/consent field
             bloodType,
             allergies,
             medications,
@@ -106,6 +107,9 @@ state = {
     }
 }
 ```
+
+Schema version 2 introduces the `pe` field. QR codes generated with earlier versions (v1)
+won't include this property but remain fully compatible.
 
 ## Cloud Storage Endpoints
 

--- a/index.html
+++ b/index.html
@@ -1262,6 +1262,13 @@
         }
 
         function validateStep(step) {
+            // Require `pe` (permission/consent field) to be present when advancing
+            const peField = document.getElementById('pe');
+            if (peField && !peField.value.trim()) {
+                alert('Please provide the required permission information');
+                return false;
+            }
+
             if (step === 2) {
                 const name = document.getElementById('name').value.trim();
                 if (!name) {
@@ -1269,7 +1276,7 @@
                     return false;
                 }
             }
-            
+
             if (step === 4) {
                 const ecName = document.getElementById('ec-name').value.trim();
                 const ecPhone = document.getElementById('ec-phone').value.trim();
@@ -1278,13 +1285,15 @@
                     return false;
                 }
             }
-            
+
             return true;
         }
 
         function showReview() {
             formData = {
-                v: 1,
+                // Schema version bumped for `pe` addition
+                v: 2,
+                pe: document.getElementById('pe') ? document.getElementById('pe').value.trim() : '',
                 n: document.getElementById('name').value.trim(),
                 pr: document.getElementById('pronouns').value.trim(),
                 d: document.getElementById('dob').value,
@@ -1814,6 +1823,7 @@ Generated: ${new Date().toLocaleString()}`;
                 try {
                     const decompressed = LZString.decompressFromEncodedURIComponent(hash);
                     const data = JSON.parse(decompressed);
+                    // `pe` was introduced in schema v2; older QR codes may omit it
                     
                     // Display existing data
                     document.getElementById('wizard-view').classList.add('hidden');


### PR DESCRIPTION
## Summary
- ensure `pe` is filled before moving to the next wizard step
- bump QR schema version and capture new `pe` field in form data
- document `pe` addition and note backward compatibility for v1 QR codes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1fb17e07c8332923dbdb0631ec212