### PR TITLE
Add Proton recovery kit download step

### DIFF
--- a/index.html
+++ b/index.html
@@ -781,9 +781,13 @@
                             <label for="proton-email">Proton Email *</label>
                             <input type="email" id="proton-email" placeholder="you@proton.me" required>
                         </div>
-                        <div style="margin-top: 20px;">
+                        <div style="margin-top: 20px; display: flex; gap: 10px; flex-wrap: wrap;">
                             <a href="https://account.proton.me/signup" target="_blank" class="btn btn-primary">Create Account</a>
+                            <a href="https://account.proton.me/u/13/safety-review/phrase" target="_blank" class="btn btn-secondary">Download Kit</a>
                         </div>
+                        <p style="margin-top: 10px; color: var(--secondary); font-size: 0.9rem;">
+                            After signing up, save the kit and share it with your case manager or someone you trust.
+                        </p>
                     </div>
 
                     <!-- Step 3: Basic Info -->


### PR DESCRIPTION
## Summary
- Add button in Proton Email setup step to download a Proton safety review kit.
- Provide guidance to share the kit with a case manager or trusted person.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1fbe4f2c483328e07c1b6ef54f808