### PR TITLE
Remove Filen references and keep Proton app links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1106,35 +1106,6 @@
     <!-- Apps Tab -->
     <div id="apps" class="tab-content">
         <div class="container">
-            <div class="resource-card">
-                <div class="resource-icon">🔐</div>
-                <h2 style="color: var(--primary); margin-bottom: 15px;">Secure Cloud Storage with Filen</h2>
-                <div style="text-align: center; margin-bottom: 20px;">
-                    <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSwL_Iiqw_VgXBMRLJX3IaUhlGQcR4Z7LWnlQ&s" alt="Filen interface" style="max-width: 100%; border-radius: 12px;">
-                </div>
-                <p style="color: var(--secondary); margin-bottom: 25px; line-height: 1.8;">
-                    Store your important documents and emergency files with military-grade encryption.
-                    Filen offers zero-knowledge end-to-end encryption - even they can't see your files.
-                </p>
-                
-                <div style="background: #eff6ff; border-left: 4px solid var(--primary); padding: 18px; margin: 25px 0; border-radius: 10px; text-align: left;">
-                    <h3 style="margin-bottom: 12px; color: var(--primary);">🚀 Getting Started</h3>
-                    <ol style="line-height: 2; color: var(--secondary); margin-left: 20px;">
-                        <li><strong>Create a free account</strong> at Filen.io (10GB free storage)</li>
-                        <li><strong>Need an email?</strong> Get a secure one at <a href="https://proton.me/mail" target="_blank" class="proton-link" style="display: inline-flex; align-items: center; gap: 8px;"><img src="https://sm.pcmag.com/pcmag_uk/review/p/proton-mai/proton-mail_zjn6.jpg" alt="Proton Mail logo" style="width:24px;height:auto;border-radius:4px;">Proton Mail</a></li>
-                        <li><strong>Upload your documents</strong> - they're encrypted on your device first</li>
-                        <li><strong>Access anywhere</strong> with apps for all platforms</li>
-                    </ol>
-                <div style="margin-top: 20px;">
-                    <input type="email" placeholder="you@proton.me" class="proton-input" style="width: 100%; padding: 12px 14px; border-radius: 10px;">
-                </div>
-
-                
-                </div>
-                
-                <a href="https://app.filen.io/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="font-size: 1.1rem; padding: 16px 40px;">
-                    Open Filen →
-
             <div class="apps-grid">
                 <a class="app-card" href="https://proton.me/mail" target="_blank" rel="noopener noreferrer">
                     <div class="app-icon">📧</div>


### PR DESCRIPTION
## Summary
- Remove Filen resource card from the apps tab
- Show only Proton application links in the apps tab

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c2e61b51308332932b5a09b83d17f8