### PR TITLE
feat: add text size settings

### DIFF
--- a/dispatch.html
+++ b/dispatch.html
@@ -10,6 +10,14 @@
             padding: 0;
             box-sizing: border-box;
         }
+        :root {
+            --base-font-size: 16px;
+        }
+
+        html {
+            font-size: var(--base-font-size);
+        }
+
         
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
@@ -555,5 +563,13 @@
             }
         });
     </script>
+<script>
+    (function() {
+        const saved = localStorage.getItem("textSize") || "normal";
+        const fontSize = saved === "grandma" ? "24px" : "16px";
+        document.documentElement.style.setProperty("--base-font-size", fontSize);
+        document.body.style.zoom = saved === "grandma" ? "1.5" : "1";
+    })();
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,12 @@
             --shadow-sm: 0 1px 3px rgba(0,0,0,0.1);
             --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
             --shadow-lg: 0 10px 25px rgba(0,0,0,0.1);
+            --base-font-size: 16px;
         }
+        html {
+            font-size: var(--base-font-size);
+        }
+
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
@@ -1222,6 +1227,20 @@
                     </a>
                 </div>
                 
+                  <div class="settings-section">
+                    <h3 style="margin-bottom: 15px; color: var(--primary);">Accessibility</h3>
+                    <div class="settings-item">
+                        <div>
+                            <div style="font-weight: 600;">📝 Text Size</div>
+                            <div style="font-size: 0.85rem; color: var(--secondary); margin-top: 5px;">Adjust interface text</div>
+                        </div>
+                        <select id="text-size-select" onchange="setTextSize(this.value)" style="padding: 6px; border-radius: 8px; border: 1px solid var(--border);">
+                            <option value="normal">Normal</option>
+                            <option value="grandma">Grandma</option>
+                        </select>
+                    </div>
+                  </div>
+
                 <div class="settings-section">
                     <h3 style="margin-bottom: 15px; color: var(--primary);">Emergency Resources</h3>
                     <div class="settings-item" onclick="alert('Suicide & Crisis Lifeline: 988')">
@@ -2192,6 +2211,26 @@ Generated: ${new Date().toLocaleString()}`;
         window.addEventListener('unload', () => {
             if (watchId) {
                 navigator.geolocation.clearWatch(watchId);
+            }
+        });
+    </script>
+
+    <script>
+        function applyTextSize(size) {
+            const fontSize = size === "grandma" ? "24px" : "16px";
+            document.documentElement.style.setProperty("--base-font-size", fontSize);
+            document.body.style.zoom = size === "grandma" ? "1.5" : "1";
+        }
+        function setTextSize(size) {
+            applyTextSize(size);
+            localStorage.setItem("textSize", size);
+        }
+        document.addEventListener("DOMContentLoaded", () => {
+            const saved = localStorage.getItem("textSize") || "normal";
+            applyTextSize(saved);
+            const select = document.getElementById("text-size-select");
+            if (select) {
+                select.value = saved;
             }
         });
     </script>

--- a/invite.html
+++ b/invite.html
@@ -23,7 +23,12 @@
             --warning: #f59e0b;
             --danger: #ef4444;
             --radius: 12px;
+            --base-font-size: 16px;
         }
+        html {
+            font-size: var(--base-font-size);
+        }
+
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -332,6 +337,14 @@
         document.getElementById('eventForm').reset();
         document.getElementById('clientEmail').value = clientEmail;
     }
+</script>
+<script>
+    (function() {
+        const saved = localStorage.getItem("textSize") || "normal";
+        const fontSize = saved === "grandma" ? "24px" : "16px";
+        document.documentElement.style.setProperty("--base-font-size", fontSize);
+        document.body.style.zoom = saved === "grandma" ? "1.5" : "1";
+    })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add base font-size variable and HTML rule for scalable text
- provide Settings option to switch between normal and grandma text sizes
- load saved text size in other pages to keep accessibility preference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c2ed8f1c6c8332871a6d2d086c4baf