### PR TITLE
Fix Proton navigation icon sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
 
         .tab-btn.proton-btn {
             padding: 0 20px;
-            height: 100%;
+            height: 56px;
         }
 
         .tab-btn.proton-btn .proton-icon {


### PR DESCRIPTION
## Summary
- Constrain Proton nav button to a fixed 56px height so the icon no longer expands to fill the entire app.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c2ef46484483328769cd9753f2d412