### PR TITLE
Add navigation option after calendar event creation

### DIFF
--- a/invite.html
+++ b/invite.html
@@ -195,6 +195,7 @@
                     <li>Attach the downloaded ICS file to your email</li>
                     <li>Send the email to invite attendees</li>
                 </ol>
+                <button type="button" class="btn btn-secondary" onclick="goHome()" style="margin-top:10px;">⬅️ Back to Main Screen</button>
             </div>
             <form id="eventForm">
                 <div class="form-group">
@@ -323,6 +324,10 @@
     function resetForm() {
         document.getElementById('eventForm').reset();
         document.getElementById('clientEmail').value = clientEmail;
+    }
+
+    function goHome() {
+        window.location.href = 'index.html';
     }
 </script>
 <script>


### PR DESCRIPTION
## Summary
- Add "Back to Main Screen" button to calendar invite confirmation
- Provide goHome helper to redirect to index.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c2f49415b48332a4f5c43ff23765fc