### PR TITLE
Use Send Event Info wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -2113,7 +2113,7 @@ Generated: ${new Date().toLocaleString()}`;
                 <div style="display: flex; justify-content: space-between; align-items: center;">
                     <div>
                         <div style="font-size: 0.75rem; text-transform: uppercase; color: var(--primary); font-weight: 700;">
-                            📅 Schedule Follow-up
+                            📅 Send Event Info
                         </div>
                         <div style="font-weight: 600; margin-top: 8px;">
                             Create calendar event with ${data.n}


### PR DESCRIPTION
## Summary
- Change label to display "Send Event Info" instead of "Schedule Follow-up"

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c2f547fc888332b76567c1e185910c