### PR TITLE
Add Calendar #2 invite generator to apps page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1311,6 +1311,11 @@
                     <h3>Proton Calendar</h3>
                     <p>Private calendar.</p>
                 </a>
+                <a class="app-card" href="invite.html">
+                    <div class="app-icon"><img src="https://pmecdn.protonweb.com/image-transformation/?s=c&amp;image=image%2Fupload%2Fstatic%2Flogos%2Ficons%2Fcalendar_ylg2jq.svg" alt="Calendar #2"></div>
+                    <h3>Calendar #2</h3>
+                    <p>Invite generator.</p>
+                </a>
                 <a class="app-card" href="https://account.proton.me/authenticator" target="_blank" rel="noopener noreferrer">
                     <div class="app-icon"><img src="https://pmecdn.protonweb.com/image-transformation/?s=c&amp;image=image%2Fupload%2Fstatic%2Flogos%2Ficons%2Fauthenticator.svg" alt="Proton Authenticator"></div>
                     <h3>Proton Authenticator</h3>


### PR DESCRIPTION
## Summary
- add Calendar #2 app card linking to invite generator

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c301ae9a4083329653028fbc6ff7c5