### PR TITLE
Add ability to remove bookmark spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ iKey Health is a client-side encrypted, progressive web application for storing 
 
 ## Favorite Apps
 
-The home screen provides a grid of favorite apps for quick access. Four slots are available by default, and additional spaces can be added as needed. Tap an app once to open it. Long-press any bookmark to enter edit mode—icons shake and a remove button appears. The add dialog can populate the grid with all Proton apps or include built-in tools like Weather and Police Dispatch.
+The home screen provides a grid of favorite apps for quick access. Four slots are available by default, and spaces can be added or removed as needed. Tap an app once to open it. Long-press any bookmark to enter edit mode—icons shake and a remove button appears. The add dialog can populate the grid with all Proton apps or include built-in tools like Weather and Police Dispatch.
 
 Bookmarks can also launch direct calls, texts, or emails to specific contacts. These shortcuts ask for a name, number or email, optional description, and photo. **All bookmarks are stored only in this browser's memory**—they will be lost if the device is lost or browser data is cleared. For secure retention, store important details separately such as a note in Proton Drive or an email to yourself.
 

--- a/index.html
+++ b/index.html
@@ -1084,6 +1084,7 @@
                     <div id="bookmark-grid" class="bookmark-grid"></div>
                     <div style="margin-top: 10px; display: flex; gap: 10px; flex-wrap: wrap;">
                         <button id="add-slot-btn" class="btn btn-secondary">Add Space</button>
+                        <button id="remove-slot-btn" class="btn btn-secondary">Remove Space</button>
                         <button id="bookmark-done" class="btn btn-primary hidden">Done</button>
                     </div>
                     <div id="communication-actions" style="margin-top: 20px;"></div>
@@ -2030,6 +2031,16 @@ END:VCALENDAR`;
             openBookmarkModal(count);
         }
 
+        function removeBookmarkSlot() {
+            let count = getBookmarkCount();
+            if (count <= 1) return;
+            const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
+            savedArr.splice(count - 1, 1);
+            localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
+            setBookmarkCount(count - 1);
+            renderBookmarkSlots();
+        }
+
         function openBookmarkModal(index) {
             const modal = document.getElementById('bookmark-modal');
             if (!modal) return;
@@ -2720,6 +2731,8 @@ Generated: ${new Date().toLocaleString()}`;
             }
             const addBtn = document.getElementById('add-slot-btn');
             if (addBtn) addBtn.addEventListener('click', addBookmarkSlot);
+            const removeBtn = document.getElementById('remove-slot-btn');
+            if (removeBtn) removeBtn.addEventListener('click', removeBookmarkSlot);
             const doneBtn = document.getElementById('bookmark-done');
             if (doneBtn) doneBtn.addEventListener('click', exitBookmarkEditMode);
         });


### PR DESCRIPTION
## Summary
- Add **Remove Space** control to bookmark grid for trimming unused slots
- Implement slot removal logic that updates stored bookmarks and re-renders grid
- Update documentation to note that favorite app spaces can be removed

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c30607b3e08332ac6e046656330fcc