### PR TITLE
Persist info panel state

### DIFF
--- a/index.html
+++ b/index.html
@@ -2697,7 +2697,9 @@ Generated: ${new Date().toLocaleString()}`;
                     document.getElementById('wizard-view').classList.add('hidden');
                     document.getElementById('display-view').classList.remove('hidden');
                     
-                    let html = `<details class="info-details"><summary style="font-size: 1.2rem; font-weight: 600;">${data.n || 'Details'}</summary><div class="details-body">`;
+                    const infoDetailsPref = localStorage.getItem('infoDetailsOpen');
+                    const detailsOpenAttr = infoDetailsPref === null || infoDetailsPref === 'true' ? ' open' : '';
+                    let html = `<details class="info-details"${detailsOpenAttr}><summary style="font-size: 1.2rem; font-weight: 600;">${data.n || 'Details'}</summary><div class="details-body">`;
 
                     if (data.ph) {
                         html += `<div class="info-card">
@@ -2760,6 +2762,12 @@ Generated: ${new Date().toLocaleString()}`;
                     html += '</div></details>';
 
                     document.getElementById('display-content').innerHTML = html;
+                    const infoDetailsEl = document.querySelector('#display-content .info-details');
+                    if (infoDetailsEl) {
+                        infoDetailsEl.addEventListener('toggle', () => {
+                            localStorage.setItem('infoDetailsOpen', infoDetailsEl.open);
+                        });
+                    }
                 } catch (e) {
                     console.error('Failed to parse URL data:', e);
                 }


### PR DESCRIPTION
## Summary
- respect stored info panel state by reading `infoDetailsOpen`
- persist personal info panel visibility on toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c31da26dd48332922a875e23927de8