### PR TITLE
Move bookmark space controls to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ iKey Health is a client-side encrypted, progressive web application for storing 
 
 ## Favorite Apps
 
-The home screen provides a grid of favorite apps for quick access. Four slots are available by default, and spaces can be added or removed as needed. Tap an app once to open it. Long-press any bookmark to enter edit mode—icons shake and a remove button appears. The add dialog can populate the grid with all Proton apps or include built-in tools like Weather and Police Dispatch.
+The home screen provides a grid of favorite apps for quick access. Four slots are available by default, and additional spaces can be added or removed from the **Settings** tab. Tap an app once to open it. Long-press any bookmark to enter edit mode—icons shake and a remove button appears. The add dialog can populate the grid with all Proton apps or include built-in tools like Weather and Police Dispatch.
 
 Bookmarks can also launch direct calls, texts, or emails to specific contacts. These shortcuts ask for a name, number or email, optional description, and photo. **All bookmarks are stored only in this browser's memory**—they will be lost if the device is lost or browser data is cleared. For secure retention, store important details separately such as a note in Proton Drive or an email to yourself.
 

--- a/index.html
+++ b/index.html
@@ -1111,8 +1111,6 @@
                     <div id="display-content"></div>
                     <div id="bookmark-grid" class="bookmark-grid"></div>
                     <div style="margin-top: 10px; display: flex; gap: 10px; flex-wrap: wrap;">
-                        <button id="add-slot-btn" class="btn btn-secondary">Add Space</button>
-                        <button id="remove-slot-btn" class="btn btn-secondary">Remove Space</button>
                         <button id="bookmark-done" class="btn btn-primary hidden">Done</button>
                     </div>
                     <div id="communication-actions" style="margin-top: 20px;"></div>
@@ -1449,6 +1447,10 @@
                 <div class="settings-section">
                     <h3 style="margin-bottom: 15px; color: var(--primary);">Favorite Apps</h3>
                     <div id="settings-bookmark-grid" class="bookmark-grid"></div>
+                    <div style="margin-top: 10px; display: flex; gap: 10px; flex-wrap: wrap;">
+                        <button id="add-slot-btn" class="btn btn-secondary">Add Space</button>
+                        <button id="remove-slot-btn" class="btn btn-secondary">Remove Space</button>
+                    </div>
                 </div>
 
                 <div class="settings-section">


### PR DESCRIPTION
## Summary
- Move add/remove bookmark space buttons from the main screen to the Settings tab
- Update README to note that space adjustments are now in Settings

## Testing
- `python -m py_compile scripts/generate_translation_doc.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c31e8b27e083328c02c4866a2a03df