### PR TITLE
Add responsive home page template with emergency strip

### DIFF
--- a/home.html
+++ b/home.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>iKey Home</title>
+  <style>
+    :root {
+      --permanent-color: #10b981;
+      --temporary-color: #64748b;
+      --live-color: #3b82f6;
+      --emergency-color: #ef4444;
+      --secondary: #666;
+      --primary: var(--live-color);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    }
+
+    body {
+      margin: 0;
+      font-family: inherit;
+    }
+
+    .home-container {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+      padding: 16px;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    .card {
+      background: white;
+      border-radius: 16px;
+      padding: 20px;
+      margin-bottom: 16px;
+    }
+
+    .emergency-strip {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      display: flex;
+      justify-content: space-around;
+      background: var(--emergency-color);
+      padding: 8px 0;
+      z-index: 1000;
+    }
+
+    .emergency-strip button {
+      height: 60px;
+      font-size: 18px;
+      font-weight: 700;
+      min-width: 44px;
+      min-height: 44px;
+      border: none;
+      background: var(--emergency-color);
+      color: white;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+
+    button, a, .clickable {
+      min-height: 44px;
+      min-width: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .button-group > * + * {
+      margin-left: 12px;
+    }
+
+    .qr-data { border-left: 4px solid var(--permanent-color); }
+    .device-data { border-left: 4px solid var(--temporary-color); }
+    .live-data { border-left: 4px solid var(--live-color); }
+
+    .text-title { font-size: 20px; font-weight: 700; margin-bottom: 8px; }
+    .text-body { font-size: 16px; line-height: 1.5; }
+    .text-caption { font-size: 14px; color: var(--secondary); }
+
+    .loading {
+      background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+      background-size: 200% 100%;
+      animation: loading 1.5s infinite;
+      height: 100px;
+      border-radius: 16px;
+    }
+
+    @keyframes loading {
+      from { background-position: 200% 0; }
+      to { background-position: -200% 0; }
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 40px 20px;
+      color: var(--secondary);
+    }
+
+    .empty-state .action {
+      margin-top: 20px;
+    }
+
+    .toast {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #333;
+      color: white;
+      padding: 12px 20px;
+      border-radius: 8px;
+      animation: slideUp 0.3s ease;
+    }
+
+    @keyframes slideUp {
+      from { transform: translate(-50%, 20px); opacity: 0; }
+      to { transform: translate(-50%, 0); opacity: 1; }
+    }
+
+    button:active {
+      transform: scale(0.95);
+      opacity: 0.8;
+    }
+
+    button:focus-visible {
+      outline: 3px solid var(--primary);
+      outline-offset: 2px;
+    }
+
+    @media (min-width: 600px) {
+      .home-container { padding: 24px; }
+      .card-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+    }
+
+    @media (min-width: 1024px) {
+      .home-container { max-width: 800px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="emergency-strip">
+    <button onclick="call911()">
+      <span class="icon">🚨</span>
+      <span class="label">911</span>
+    </button>
+    <button onclick="quickShare()">
+      <span class="icon">📍</span>
+      <span class="label">Location</span>
+    </button>
+    <button onclick="showQR()">
+      <span class="icon">🏥</span>
+      <span class="label">Medical</span>
+    </button>
+  </div>
+
+  <div class="home-container" style="padding-top: 80px;">
+    <div class="card qr-data">
+      <div class="text-title">Example Card</div>
+      <div class="text-body">This card uses the permanent data style.</div>
+    </div>
+
+    <div class="loading"></div>
+
+    <div class="empty-state">
+      <p>No data yet</p>
+      <button class="action">Add Info</button>
+    </div>
+  </div>
+
+  <div id="toast" class="toast" style="display: none"></div>
+
+  <script>
+    const CARD_PRIORITY = {
+      emergency_strip: 0,
+      medical_alert: 1,
+      current_location: 2,
+      emergency_contacts: 3,
+      weather_alerts: 4,
+      quick_access: 5,
+      backup_restore: 6
+    };
+
+    const ERROR_MESSAGES = {
+      location_denied: "Location access needed for emergency features",
+      storage_full: "Device storage full - bookmarks may not save",
+      offline: "Offline - showing cached information",
+      qr_invalid: "QR code damaged - create a new one"
+    };
+
+    function showToast(msg) {
+      const t = document.getElementById('toast');
+      t.textContent = msg;
+      t.style.display = 'block';
+      setTimeout(() => t.style.display = 'none', 3000);
+    }
+
+    function showError(type) {
+      const msg = ERROR_MESSAGES[type] || 'Unknown error';
+      showToast(msg);
+    }
+
+    function call911() {
+      showToast('Calling 911…');
+    }
+    function quickShare() {
+      showToast('Sharing location…');
+    }
+    function showQR() {
+      showToast('Showing medical QR…');
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `home.html` demonstrating responsive grid layout and typography
- implement fixed emergency strip with 911, location, and medical buttons
- add color-coded data cards, loading/empty states, and toast-based error handling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c321f4598483329eb7de36b6b8209d