### PR TITLE
Add QR code sharing option

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -88,6 +88,7 @@ List of user-visible strings requiring translation for full multilingual support
 - 📧 Email
 - 📋 Copy
 - 💬 Text
+- 🔳 Share QR
 - Close
 - Emergency Call 911
 - Tap to Call Emergency Services

--- a/index.html
+++ b/index.html
@@ -1355,6 +1355,7 @@
             <button class="btn btn-primary" onclick="emailInfo()">📧 Email</button>
             <button class="btn btn-primary" onclick="copyMedicalInfo(displayData)">📋 Copy</button>
             <button class="btn btn-primary" onclick="smsInfo()">💬 Text</button>
+            <button class="btn btn-primary" onclick="shareQR()">🔳 Share QR</button>
             <button class="btn btn-secondary" onclick="closeShareModal()">Close</button>
         </div>
     </div>
@@ -2079,6 +2080,24 @@
         function smsInfo() {
             const text = encodeURIComponent(getMedicalInfoText(displayData));
             window.location.href = `sms:?body=${text}`;
+        }
+
+        function shareQR() {
+            const canvas = document.querySelector('#qrcode canvas');
+            if (!canvas) return;
+            canvas.toBlob(function(blob) {
+                const file = new File([blob], 'ikey-qr.png', { type: 'image/png' });
+                const shareData = { files: [file], title: 'iKey QR Code', text: 'Scan to view my emergency info' };
+                if (navigator.share && navigator.canShare && navigator.canShare({ files: [file] })) {
+                    navigator.share(shareData).catch(err => console.error('Share failed:', err));
+                } else {
+                    const link = document.createElement('a');
+                    link.download = 'ikey-qr.png';
+                    link.href = URL.createObjectURL(blob);
+                    link.click();
+                    URL.revokeObjectURL(link.href);
+                }
+            });
         }
 
         function createNew() {


### PR DESCRIPTION
## Summary
- allow sharing the generated QR code from the Share Contact Info modal
- expose a shareQR helper that uses the Web Share API with a download fallback
- document new "🔳 Share QR" term for translations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3412c46b08332a9f7cd8d20c1c5cb