### PR TITLE
Remove emergency strip from home page

### DIFF
--- a/home.html
+++ b/home.html
@@ -36,32 +36,6 @@
       margin-bottom: 16px;
     }
 
-    .emergency-strip {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      display: flex;
-      justify-content: space-around;
-      background: var(--emergency-color);
-      padding: 4px 0;
-      z-index: 1000;
-    }
-
-    .emergency-strip button {
-      height: 44px;
-      font-size: 16px;
-      font-weight: 700;
-      min-width: 44px;
-      min-height: 44px;
-      border: none;
-      background: var(--emergency-color);
-      color: white;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-    }
 
     button, a, .clickable {
       min-height: 44px;
@@ -166,22 +140,7 @@
   </style>
 </head>
 <body>
-  <div class="emergency-strip">
-    <button onclick="call911()">
-      <span class="icon">🚨</span>
-      <span class="label">911</span>
-    </button>
-    <button onclick="quickShare()">
-      <span class="icon">📍</span>
-      <span class="label">Location</span>
-    </button>
-    <button onclick="showQR()">
-      <span class="icon">🏥</span>
-      <span class="label">Medical</span>
-    </button>
-  </div>
-
-  <div id="card-container" class="home-container" style="padding-top: 64px;">
+  <div id="card-container" class="home-container">
     <div class="loading"></div>
   </div>
 
@@ -189,13 +148,12 @@
 
   <script>
     const CARD_PRIORITY = {
-      emergency_strip: 0,
-      medical_alert: 1,
-      current_location: 2,
-      emergency_contacts: 3,
-      weather_alerts: 4,
-      quick_access: 5,
-      backup_restore: 6
+      medical_alert: 0,
+      current_location: 1,
+      emergency_contacts: 2,
+      weather_alerts: 3,
+      quick_access: 4,
+      backup_restore: 5
     };
 
     const ERROR_MESSAGES = {
@@ -376,9 +334,6 @@
     function fix_offline() { showToast('Retrying…'); }
     function fix_qr_invalid() { showToast('Generating new QR…'); }
 
-    function call911() { showToast('Calling 911…'); }
-    function quickShare() { showToast('Sharing location…'); }
-    function showQR() { showToast('Showing medical QR…'); }
 
     document.addEventListener('DOMContentLoaded', () => {
       setTimeout(renderHome, 1000);

--- a/index.html
+++ b/index.html
@@ -893,49 +893,6 @@
             z-index: 1000;
         }
 
-        /* Emergency Strip Styles */
-        .emergency-strip {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 12px;
-            margin-bottom: 20px;
-            background: white;
-            padding: 16px;
-            border-radius: var(--radius);
-            box-shadow: var(--shadow-lg);
-            position: sticky;
-            top: 0;
-            z-index: 100;
-        }
-
-        .emergency-action {
-            height: 80px;
-            background: linear-gradient(135deg, #ef4444, #dc2626);
-            color: white;
-            border: none;
-            border-radius: 12px;
-            font-weight: 700;
-            cursor: pointer;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            gap: 4px;
-            transition: transform 0.2s;
-        }
-
-        .emergency-action:active {
-            transform: scale(0.95);
-        }
-
-        .emergency-action .icon {
-            font-size: 32px;
-        }
-
-        .emergency-action .label {
-            font-size: 14px;
-            text-transform: uppercase;
-        }
 
         /* Status Cards */
         .status-container {
@@ -1092,22 +1049,6 @@
     <!-- Home Tab -->
     <div id="home" class="tab-content">
         <div class="container">
-            <!-- Emergency Strip - Always visible -->
-            <div class="emergency-strip">
-                <button class="emergency-action" onclick="call911()">
-                    <span class="icon">🚨</span>
-                    <span class="label">911</span>
-                </button>
-                <button class="emergency-action" onclick="quickShareLocation()">
-                    <span class="icon">📍</span>
-                    <span class="label">Share</span>
-                </button>
-                <button class="emergency-action" onclick="quickMedical()">
-                    <span class="icon">🏥</span>
-                    <span class="label">Medical</span>
-                </button>
-            </div>
-
             <!-- Status Cards Container -->
             <div id="status-cards" class="status-container">
                 <!-- Populated by JavaScript -->
@@ -2852,62 +2793,6 @@ Generated: ${new Date().toLocaleString()}`;
 
         let displayData = null;
 
-        // Add these new functions
-        function quickShareLocation() {
-            // Get current location and share immediately
-            if (navigator.geolocation) {
-                navigator.geolocation.getCurrentPosition(
-                    position => {
-                        const lat = position.coords.latitude;
-                        const lon = position.coords.longitude;
-                        const shareText = `Emergency Location:\n${lat}, ${lon}\nhttps://maps.google.com/?q=${lat},${lon}`;
-
-                        if (navigator.share) {
-                            navigator.share({
-                                title: 'Emergency Location',
-                                text: shareText
-                            });
-                        } else {
-                            navigator.clipboard.writeText(shareText);
-                            alert('Location copied to clipboard!');
-                        }
-                    },
-                    error => {
-                        alert('Cannot access location. Please enable location services.');
-                    }
-                );
-            }
-        }
-
-        function quickMedical() {
-            if (displayData) {
-                // Show QR modal
-                const modal = document.createElement('div');
-                modal.className = 'modal';
-                modal.innerHTML = `
-            <div class="modal-content" style="text-align: center;">
-                <h2>Medical Information</h2>
-                <div id="quick-qr"></div>
-                <button class="btn btn-primary" onclick="this.closest('.modal').remove()">Close</button>
-            </div>
-        `;
-                document.body.appendChild(modal);
-
-                // Generate QR in modal
-                new QRCode(document.getElementById('quick-qr'), {
-                    text: window.location.href,
-                    width: 200,
-                    height: 200
-                });
-            } else {
-                // Redirect to iKey tab to create
-                switchTab('ikey');
-            }
-        }
-
-        function call911() {
-            window.location.href = 'tel:911';
-        }
 
         function renderHomeStatus() {
             const container = document.getElementById('status-cards');


### PR DESCRIPTION
## Summary
- Remove emergency action strip and related code from home page templates.
- Adjust card ordering constants now that emergency strip is gone.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c34239eb90833285ca0dd5c015e3d5