### PR TITLE
Fix bookmark storage and refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -2231,7 +2231,7 @@ END:VCALENDAR`;
         }
 
         function loadBookmarks() {
-            const saved = JSON.parse(storage.get('protonBookmarks') || '[]');
+            const saved = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
             const count = getBookmarkCount();
             for (let i = 0; i < count; i++) {
                 document.querySelectorAll(`.bookmark-slot[data-index="${i}"]`).forEach(slot => {
@@ -2308,10 +2308,10 @@ END:VCALENDAR`;
                         };
                         removeBtn.addEventListener('click', (e) => {
                             e.stopPropagation();
-                            const savedArr = JSON.parse(storage.get('protonBookmarks') || '[]');
+                            const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
                             savedArr[i] = null;
-                            storage.set('protonBookmarks', JSON.stringify(savedArr));
-                            loadBookmarks();
+                            localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
+                            refreshAllBookmarkGrids();
                         });
                     } else {
                         slot.classList.add('empty');
@@ -2320,6 +2320,11 @@ END:VCALENDAR`;
                     }
                 });
             }
+        }
+
+        function refreshAllBookmarkGrids() {
+            renderBookmarkSlots();
+            renderHomeStatus();
         }
 
         function addLongPress(el, callback) {
@@ -2355,7 +2360,7 @@ END:VCALENDAR`;
             let count = getBookmarkCount();
             if (count >= MAX_BOOKMARKS) return;
             setBookmarkCount(count + 1);
-            renderBookmarkSlots();
+            refreshAllBookmarkGrids();
             openBookmarkModal(count);
         }
 
@@ -2366,16 +2371,16 @@ END:VCALENDAR`;
             savedArr.splice(count - 1, 1);
             localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
             setBookmarkCount(count - 1);
-            renderBookmarkSlots();
+            refreshAllBookmarkGrids();
         }
 
         function moveBookmark(from, to) {
-            const savedArr = JSON.parse(storage.get('protonBookmarks') || '[]');
+            const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
             if (from === to || from < 0 || to < 0 || from >= savedArr.length || to >= savedArr.length) return;
             const [moved] = savedArr.splice(from, 1);
             savedArr.splice(to, 0, moved);
-            storage.set('protonBookmarks', JSON.stringify(savedArr));
-            loadBookmarks();
+            localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
+            refreshAllBookmarkGrids();
         }
 
         function openBookmarkModal(index) {
@@ -2385,7 +2390,7 @@ END:VCALENDAR`;
             modal.innerHTML = `<div class="modal-content"><h3>Select Favorite</h3><p class="bookmark-warning">⚠️ Bookmarks are saved only in this browser and will be lost if the device is lost or data is cleared. For secure backup, add a note in Proton Drive or save in an email.</p><div id="modal-app-list"></div></div>`;
             const list = document.getElementById('modal-app-list');
             if (list) {
-                const saved = JSON.parse(storage.get('protonBookmarks') || '[]');
+                const saved = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
                 const usedIds = saved.map((entry, idx) => {
                     if (idx === index || !entry) return null;
                     return typeof entry === 'string' ? entry : entry.id;
@@ -2409,16 +2414,16 @@ END:VCALENDAR`;
                 list.querySelectorAll('.modal-app').forEach(el => {
                     if (el.dataset.id) {
                         el.addEventListener('click', () => {
-                            const savedArr = JSON.parse(storage.get('protonBookmarks') || '[]');
+                            const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
                             if (el.dataset.type === 'proton') {
                                 savedArr[index] = { id: el.dataset.id };
                             } else if (el.dataset.type === 'internal') {
                                 const app = INTERNAL_APPS.find(a => a.id === el.dataset.id);
                                 savedArr[index] = { id: app.id, url: app.url, name: app.name, icon: app.icon };
                             }
-                            storage.set('protonBookmarks', JSON.stringify(savedArr));
+                            localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
                             closeBookmarkModal();
-                            renderBookmarkSlots();
+                            refreshAllBookmarkGrids();
                         });
                     } else if (el.id === 'add-custom') {
                         el.addEventListener('click', () => {
@@ -2431,11 +2436,11 @@ END:VCALENDAR`;
                                 const urlObj = new URL(normalizedUrl);
                                 const name = prompt('Enter a name for this website') || urlObj.hostname;
                                 const icon = `https://www.google.com/s2/favicons?sz=64&domain=${urlObj.hostname}`;
-                                const savedArr = JSON.parse(storage.get('protonBookmarks') || '[]');
+                                const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
                                 savedArr[index] = { url: urlObj.href, name, icon };
-                                storage.set('protonBookmarks', JSON.stringify(savedArr));
+                                localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
                                 closeBookmarkModal();
-                                renderBookmarkSlots();
+                                refreshAllBookmarkGrids();
                             } catch (e) {
                                 alert('Invalid URL');
                             }
@@ -2446,20 +2451,25 @@ END:VCALENDAR`;
                         });
                     } else if (el.dataset.remove) {
                         el.addEventListener('click', () => {
-                            const savedArr = JSON.parse(storage.get('protonBookmarks') || '[]');
+                            const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
                             savedArr[index] = null;
-                            storage.set('protonBookmarks', JSON.stringify(savedArr));
+                            localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
                             closeBookmarkModal();
-                            renderBookmarkSlots();
+                            refreshAllBookmarkGrids();
                         });
                     } else if (el.id === 'add-all-proton') {
                         el.addEventListener('click', () => {
-                            const savedArr = [];
+                            const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
+                            const hasProtonApps = savedArr.some(b => b?.id && PROTON_APPS.find(a => a.id === b.id));
+                            if (hasProtonApps) {
+                                alert('Some Proton apps are already bookmarked');
+                                return;
+                            }
                             PROTON_APPS.forEach(app => savedArr.push({ id: app.id }));
-                            storage.set('protonBookmarks', JSON.stringify(savedArr));
-                            setBookmarkCount(Math.max(getBookmarkCount(), PROTON_APPS.length));
+                            localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
+                            setBookmarkCount(Math.max(getBookmarkCount(), savedArr.length));
                             closeBookmarkModal();
-                            renderBookmarkSlots();
+                            refreshAllBookmarkGrids();
                         });
                     }
                 });
@@ -2487,11 +2497,11 @@ END:VCALENDAR`;
                     const urlObj = new URL(url);
                     const name = nameInput.value.trim() || urlObj.hostname;
                     const icon = `https://www.google.com/s2/favicons?sz=64&domain=${urlObj.hostname}`;
-                    const savedArr = JSON.parse(storage.get('protonBookmarks') || '[]');
+                    const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
                     savedArr[index] = { url: urlObj.href, name, icon };
-                    storage.set('protonBookmarks', JSON.stringify(savedArr));
+                    localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
                     closeBookmarkModal();
-                    renderBookmarkSlots();
+                    refreshAllBookmarkGrids();
                 } catch (e) {
                     showTooltip('Invalid URL', urlInput);
                 }
@@ -2534,11 +2544,11 @@ END:VCALENDAR`;
                     showTooltip('Please enter a ' + (type === 'email' ? 'email address' : 'phone number'), document.getElementById('contact-value'));
                     return;
                 }
-                const savedArr = JSON.parse(storage.get('protonBookmarks') || '[]');
+                const savedArr = JSON.parse(localStorage.getItem('protonBookmarks') || '[]');
                 savedArr[index] = { type, value, name, description: desc, photo: photoData };
-                storage.set('protonBookmarks', JSON.stringify(savedArr));
+                localStorage.setItem('protonBookmarks', JSON.stringify(savedArr));
                 closeBookmarkModal();
-                renderBookmarkSlots();
+                refreshAllBookmarkGrids();
             });
             document.getElementById('cancel-contact').addEventListener('click', () => {
                 closeBookmarkModal();
@@ -2996,7 +3006,7 @@ Generated: ${new Date().toLocaleString()}`;
             const container = document.getElementById('quick-access');
             if (!container) return;
 
-            const savedBookmarks = JSON.parse(storage.get('protonBookmarks') || '[]').filter(Boolean);
+            const savedBookmarks = JSON.parse(localStorage.getItem('protonBookmarks') || '[]').filter(Boolean);
 
             if (savedBookmarks.length === 0) return;
 
@@ -3223,7 +3233,7 @@ Generated: ${new Date().toLocaleString()}`;
                 }
             });
 
-            renderBookmarkSlots();
+            refreshAllBookmarkGrids();
             const modal = document.getElementById('bookmark-modal');
             if (modal) {
                 modal.addEventListener('click', function(e) {


### PR DESCRIPTION
## Summary
- store bookmarks in global `localStorage` and remove namespace prefix
- add `refreshAllBookmarkGrids` to sync home and settings grids
- prevent duplicate Proton apps when using "Add All"

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c34c537fb4833283da5e83bf4b6812