### PR TITLE
Rename WTTIN tab to Resources and adjust visibility

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -8,7 +8,7 @@
       "home": "Home",
       "iKey": "iKey",
       "weather": "Weather",
-      "wttin": "WTTIN",
+      "wttin": "Resources",
       "meals": "Meals",
       "dispatch": "Dispatch",
       "settings": "Settings"
@@ -266,7 +266,7 @@
       "fillRequiredFields": "Please fill in all required fields"
     },
     "resources": {
-      "wttin": "WTTIN Resources",
+      "wttin": "Resources",
       "meals": "Meals Resources",
       "policeDispatch": "Nashville Police Dispatch",
       "crisisLine": "Suicide & Crisis Lifeline: 988",
@@ -289,7 +289,7 @@
       "home": "Inicio",
       "iKey": "iKey",
       "weather": "Clima",
-      "wttin": "WTTIN",
+      "wttin": "Resources",
       "meals": "Comidas",
       "dispatch": "Despacho",
       "settings": "Configuración"
@@ -547,7 +547,7 @@
       "fillRequiredFields": "Por favor completa todos los campos requeridos"
     },
     "resources": {
-      "wttin": "Recursos WTTIN",
+      "wttin": "Resources",
       "meals": "Recursos de Comidas",
       "policeDispatch": "Despacho Policial de Nashville",
       "crisisLine": "Línea de Suicidio y Crisis: 988",
@@ -570,7 +570,7 @@
       "home": "الرئيسية",
       "iKey": "iKey",
       "weather": "الطقس",
-      "wttin": "WTTIN",
+      "wttin": "Resources",
       "meals": "الوجبات",
       "dispatch": "الإرسال",
       "settings": "الإعدادات"
@@ -828,7 +828,7 @@
       "fillRequiredFields": "يرجى ملء جميع الحقول المطلوبة"
     },
     "resources": {
-      "wttin": "موارد WTTIN",
+      "wttin": "Resources",
       "meals": "موارد الوجبات",
       "policeDispatch": "إرسال شرطة ناشفيل",
       "crisisLine": "خط الأزمات والانتحار: 988",
@@ -851,7 +851,7 @@
       "home": "Mal",
       "iKey": "iKey",
       "weather": "Hewa",
-      "wttin": "WTTIN",
+      "wttin": "Resources",
       "meals": "Xwarin",
       "dispatch": "Şandin",
       "settings": "Mîheng"
@@ -1109,7 +1109,7 @@
       "fillRequiredFields": "Ji kerema xwe hemû qadên pêwîst dagirin"
     },
     "resources": {
-      "wttin": "Çavkaniyên WTTIN",
+      "wttin": "Resources",
       "meals": "Çavkaniyên Xwarinan",
       "policeDispatch": "Şandina Polîsê Nashville",
       "crisisLine": "Xeta Xwekujtin û Krîzê: 988",
@@ -1132,7 +1132,7 @@
       "home": "Guri",
       "iKey": "iKey",
       "weather": "Cimilada",
-      "wttin": "WTTIN",
+      "wttin": "Resources",
       "meals": "Cunto",
       "dispatch": "Dirista",
       "settings": "Dejinta"
@@ -1390,7 +1390,7 @@
       "fillRequiredFields": "Fadlan buuxi dhammaan beeraha loo baahan yahay"
     },
     "resources": {
-      "wttin": "Ilaha WTTIN",
+      "wttin": "Resources",
       "meals": "Ilaha Cuntada",
       "policeDispatch": "Dirista Booliska Nashville",
       "crisisLine": "Khadka Ismiidaaminta & Dhibaatada: 988",
@@ -1413,7 +1413,7 @@
       "home": "主页",
       "iKey": "iKey",
       "weather": "天气",
-      "wttin": "WTTIN",
+      "wttin": "Resources",
       "meals": "餐食",
       "dispatch": "调度",
       "settings": "设置"
@@ -1671,7 +1671,7 @@
       "fillRequiredFields": "请填写所有必填字段"
     },
     "resources": {
-      "wttin": "WTTIN资源",
+      "wttin": "Resources",
       "meals": "餐食资源",
       "policeDispatch": "纳什维尔警察调度",
       "crisisLine": "自杀与危机生命线：988",

--- a/index.html
+++ b/index.html
@@ -557,7 +557,7 @@
             border-color: var(--primary);
         }
 
-        /* WTTIN Tab */
+        /* Resources Tab */
         .iframe-container {
             position: relative;
             width: 100%;
@@ -1051,11 +1051,11 @@
             <span class="tab-icon">⛈️</span>
             <span class="tab-label" data-i18n="nav.weather">Weather</span>
         </button>
-        <button class="tab-btn" onclick="switchTab('wttin')" aria-label="WTTIN" data-i18n-aria="nav.wttin">
+        <button class="tab-btn" onclick="switchTab('wttin')" aria-label="Resources" data-i18n-aria="nav.wttin">
             <img src="https://wttin.org/wp-content/uploads/2024/05/Group-184-1.png"
-                 alt="WTTIN"
+                 alt="Resources"
                  style="width: 20px; height: 20px; object-fit: contain;">
-            <span class="tab-label" data-i18n="nav.wttin">WTTIN</span>
+            <span class="tab-label" data-i18n="nav.wttin">Resources</span>
         </button>
         <button class="tab-btn" onclick="switchTab('meals')" aria-label="Meals" data-i18n-aria="nav.meals">
             <span class="tab-icon">🍽️</span>
@@ -1581,14 +1581,14 @@
         </div>
     </div>
 
-    <!-- WTTIN Tab -->
+    <!-- Resources Tab -->
     <div id="wttin" class="tab-content">
         <div style="height: calc(100vh - 120px); display: flex; flex-direction: column;">
             <div style="flex: 1; position: relative;">
                 <iframe
                     src="https://wttin.org"
                     sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-                    title="WTTIN Resources"
+                    title="Resources"
                     loading="lazy"
                     style="width: 100%; height: 100%; border: none;">
                 </iframe>
@@ -1739,18 +1739,6 @@
                     <h3 style="margin-bottom: 15px; color: var(--primary);">Tab Visibility</h3>
                     <div class="settings-item" style="cursor: default;">
                         <div>
-                            <div style="font-weight: 600;">🏠 Home</div>
-                        </div>
-                        <input type="checkbox" class="tab-visibility-toggle" data-tab="home" checked>
-                    </div>
-                    <div class="settings-item" style="cursor: default;">
-                        <div>
-                            <div style="font-weight: 600;">🏥 iKey</div>
-                        </div>
-                        <input type="checkbox" class="tab-visibility-toggle" data-tab="ikey" checked>
-                    </div>
-                    <div class="settings-item" style="cursor: default;">
-                        <div>
                             <div style="font-weight: 600;">🚨 911</div>
                         </div>
                         <input type="checkbox" class="tab-visibility-toggle" data-tab="emergency-911" checked>
@@ -1763,7 +1751,7 @@
                     </div>
                     <div class="settings-item" style="cursor: default;">
                         <div>
-                            <div style="font-weight: 600;">WTTIN</div>
+                            <div style="font-weight: 600;" data-i18n="nav.wttin">Resources</div>
                         </div>
                         <input type="checkbox" class="tab-visibility-toggle" data-tab="wttin" checked>
                     </div>
@@ -1885,7 +1873,8 @@
         }
 
         // Tab visibility settings
-        const allTabs = ['home', 'ikey', 'emergency-911', 'weather', 'wttin', 'apps'];
+        const allTabs = ['emergency-911', 'weather', 'wttin', 'apps'];
+        const nonHideableTabs = ['home', 'ikey', 'settings'];
 
         function getTabButton(tabName) {
             return Array.from(document.querySelectorAll('.tab-btn')).find(btn =>
@@ -1894,7 +1883,9 @@
         }
 
         function applyHiddenTabs() {
-            const hidden = JSON.parse(localStorage.getItem('hiddenTabs') || '[]');
+            let hidden = JSON.parse(localStorage.getItem('hiddenTabs') || '[]');
+            hidden = hidden.filter(tab => !nonHideableTabs.includes(tab));
+            localStorage.setItem('hiddenTabs', JSON.stringify(hidden));
             allTabs.forEach(tab => {
                 const btn = getTabButton(tab);
                 if (btn) {
@@ -1912,6 +1903,7 @@
         }
 
         function toggleTabVisibility(tab, isVisible) {
+            if (nonHideableTabs.includes(tab)) return;
             let hidden = JSON.parse(localStorage.getItem('hiddenTabs') || '[]');
             if (!isVisible) {
                 if (!hidden.includes(tab)) hidden.push(tab);


### PR DESCRIPTION
## Summary
- Rename the WTTIN tab and related content to **Resources**
- Allow hiding the Resources tab via settings while keeping Home, iKey, and Settings always visible
- Filter tab visibility logic to prevent non-hideable tabs from being hidden

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3528a36e483328f5622129319ff13