### PR TITLE
Ensure home screen renders after DOM is ready

### DIFF
--- a/home.html
+++ b/home.html
@@ -437,9 +437,15 @@
     function fix_qr_invalid() { showToast('Generating new QR…'); }
 
 
-    document.addEventListener('DOMContentLoaded', () => {
+    function initHome() {
       setTimeout(renderHome, 1000);
-    });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initHome);
+    } else {
+      initHome();
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Fix home screen initialization so content renders even when the DOM is already loaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c357c223948332b00f7791122b3f32