### PR TITLE
Handle missing translations gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -3165,9 +3165,18 @@ Generated: ${new Date().toLocaleString()}`;
         }
         let translations = {};
         fetch('TRANSLATION_TERMS.md')
-            .then(resp => resp.json())
-            .then(data => {
-                translations = data;
+            .then(resp => resp.text())
+            .then(text => {
+                try {
+                    translations = JSON.parse(text);
+                } catch (e) {
+                    console.error('Failed to parse translations:', e);
+                }
+            })
+            .catch(err => {
+                console.error('Failed to load translations:', err);
+            })
+            .finally(() => {
                 const saved = localStorage.getItem('language') || 'en';
                 setLanguage(saved);
             });


### PR DESCRIPTION
## Summary
- Avoid blank screen when translation terms fail to load
- Default language now set even if translation file cannot be fetched

## Testing
- `python -m py_compile scripts/generate_translation_doc.py`


------
https://chatgpt.com/codex/tasks/task_b_68c35a842e188332bc8eeece6db66414