### PR TITLE
Fix missing brace in renderHomeStatus

### DIFF
--- a/index.html
+++ b/index.html
@@ -2895,6 +2895,7 @@ Generated: ${new Date().toLocaleString()}`;
             </div>
         `;
             }
+        }
 
 
         // Initialize


### PR DESCRIPTION
## Summary
- close renderHomeStatus function in index.html to fix JavaScript syntax error

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c35be5ceac833296a1372fff4fb649