### PR TITLE
Add iKey logo to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,11 @@
             color: var(--primary);
         }
 
+        .app-header .logo {
+            width: 32px;
+            height: 32px;
+        }
+
         .app-header p {
             font-size: 0.9rem;
             color: var(--secondary);
@@ -981,7 +986,7 @@
                 <button class="lang-option" data-lang="zh" aria-label="中文">文</button>
             </div>
         </div>
-        <h1 data-i18n="appLogo">🔐 iKey</h1>
+        <h1><img src="https://storage.googleapis.com/art_homelessness/1.png" alt="iKey logo" class="logo"> iKey</h1>
         <p data-i18n="appTagline">Secure Location & Personal Safety Hub</p>
     </div>
 


### PR DESCRIPTION
## Summary
- Replace text-based header with iKey logo image for a branded look.
- Style new logo in header for consistent sizing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3605d0fa4833287eb2f749df3854f