### PR TITLE
Centralize translation handling and annotate pages

### DIFF
--- a/dispatch.html
+++ b/dispatch.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Nashville Police Active Dispatches</title>
+    <title data-i18n="dispatch.title">Nashville Police Active Dispatches</title>
+    <script src="scripts/translate.js"></script>
     <style>
         * {
             margin: 0;
@@ -324,34 +325,34 @@
 <body>
     <div class="container">
         <div class="header">
-            <div class="title">
+            <div class="title" data-i18n="dispatch.header">
                 📡 Nashville Police Dispatches
                 <span class="refresh-dot"></span>
             </div>
-            <div class="subtitle">Real-time incident monitoring • Updates every 30 seconds</div>
+            <div class="subtitle" data-i18n="dispatch.subtitle">Real-time incident monitoring • Updates every 30 seconds</div>
             <div class="stats">
                 <div class="stat">
-                    <div class="stat-label">Active</div>
+                    <div class="stat-label" data-i18n="dispatch.active">Active</div>
                     <div class="stat-value" id="totalCalls">0</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-label">Latest</div>
+                    <div class="stat-label" data-i18n="dispatch.latest">Latest</div>
                     <div class="stat-value small" id="mostRecent">--</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-label">Updated</div>
+                    <div class="stat-label" data-i18n="dispatch.updated">Updated</div>
                     <div class="stat-value small" id="lastUpdate">--:--</div>
                 </div>
             </div>
         </div>
         
         <div id="dispatchList">
-            <div class="loading">
-                <div class="loading-spinner"></div>
-                <div>Loading dispatches...</div>
+                <div class="loading">
+                    <div class="loading-spinner"></div>
+                    <div data-i18n="dispatch.loading">Loading dispatches...</div>
+                </div>
             </div>
         </div>
-    </div>
     
     <script>
         const API_URL = 'https://services2.arcgis.com/HdTo6HJqh92wn4D8/arcgis/rest/services/Metro_Nashville_Police_Department_Active_Dispatch_Table_view/FeatureServer/0/query?where=1%3D1&outFields=*&outSR=4326&f=json';
@@ -485,8 +486,8 @@
                     dispatchList.innerHTML = `
                         <div class="empty">
                             <div class="empty-icon">✅</div>
-                            <div class="empty-title">All Clear</div>
-                            <div class="empty-subtitle">No active dispatches at this time</div>
+                            <div class="empty-title">${t('dispatch.allClear', 'All Clear')}</div>
+                            <div class="empty-subtitle">${t('dispatch.none', 'No active dispatches at this time')}</div>
                         </div>
                     `;
                     return;
@@ -514,7 +515,7 @@
                             <div class="dispatch-location">
                                 <div class="location-primary">
                                     <span class="location-icon">📍</span>
-                                    <span>${attr.Location || 'Location not specified'}</span>
+                                    <span>${attr.Location || t('dispatch.locationNotSpecified', 'Location not specified')}</span>
                                     ${attr.CityName ? `<span class="city-badge">${attr.CityName}</span>` : ''}
                                 </div>
                                 ${attr.LocationDescription ? `

--- a/home.html
+++ b/home.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>iKey Home</title>
+  <title data-i18n="homeTitle">iKey Home</title>
+  <script src="scripts/translate.js"></script>
   <style>
     :root {
       --permanent-color: #10b981;
@@ -158,10 +159,10 @@
     };
 
     const ERROR_MESSAGES = {
-      location_denied: "Location access needed for emergency features",
-      storage_full: "Device storage full - bookmarks may not save",
-      offline: "Offline - showing cached information",
-      qr_invalid: "QR code damaged - create a new one"
+      location_denied: () => t('home.error.locationDenied', 'Location access needed for emergency features'),
+      storage_full: () => t('home.error.storageFull', 'Device storage full - bookmarks may not save'),
+      offline: () => t('home.error.offline', 'Offline - showing cached information'),
+      qr_invalid: () => t('home.error.qrInvalid', 'QR code damaged - create a new one')
     };
 
     let editMode = false;
@@ -239,9 +240,9 @@
 
     function renderDataCard(card) {
       const badges = {
-        qr: { icon: '🔒', text: 'Permanent', color: 'green', class: 'qr-data' },
-        device: { icon: '📱', text: 'Device Only', color: 'gray', class: 'device-data' },
-        live: { icon: '🔄', text: 'Live', color: 'blue', class: 'live-data' }
+        qr: { icon: '🔒', text: t('home.badges.permanent', 'Permanent'), color: 'green', class: 'qr-data' },
+        device: { icon: '📱', text: t('home.badges.deviceOnly', 'Device Only'), color: 'gray', class: 'device-data' },
+        live: { icon: '🔄', text: t('home.badges.live', 'Live'), color: 'blue', class: 'live-data' }
       };
       const b = badges[card.source];
       return `
@@ -262,10 +263,10 @@
       return `
         <div class="medical-card">
           <div class="always-visible">
-            ${critical ? `⚠️ ${critical}` : 'No critical alerts'}
+            ${critical ? `⚠️ ${critical}` : t('home.noCriticalAlerts', 'No critical alerts')}
           </div>
           <details class="additional-info">
-            <summary>View all medical info</summary>
+            <summary>${t('home.viewAllMedical', 'View all medical info')}</summary>
             ${renderFullMedical(data)}
           </details>
         </div>
@@ -280,7 +281,7 @@
       const details = apps.map((app, index) => ({ info: getBookmarkDetails(app), index }))
                           .filter(d => d.info);
       if (details.length === 0 && !editMode) {
-        return `<div class="text-body">No favorites yet</div>`;
+        return `<div class="text-body">${t('home.noFavorites', 'No favorites yet')}</div>`;
       }
       const listHtml = details.map(d => `
             <div class="favorite" draggable="${editMode}" data-index="${d.index}" data-url="${d.info.url}">
@@ -294,7 +295,7 @@
         <div class="favorites ${editMode ? 'editing' : ''}" id="favorites">
           ${listHtml}${addTile}
         </div>
-        ${editMode ? '<div class="button-group"><button onclick="exitEdit()">Done</button></div>' : ''}
+        ${editMode ? `<div class="button-group"><button onclick="exitEdit()">${t('common.done', 'Done')}</button></div>` : ''}
       `;
     }
 
@@ -373,32 +374,32 @@
     }
 
     function addFavorite() {
-      const type = prompt('Add proton app id, "dispatch", "website", "call", "text", or "email"');
+      const type = prompt(t('home.addPrompt', 'Add proton app id, "dispatch", "website", "call", "text", or "email"'));
       if (!type) return;
       if (PROTON_APPS.find(a => a.id === type)) {
         favoriteApps.push(type);
       } else if (INTERNAL_APPS.find(a => a.id === type)) {
         favoriteApps.push(type);
       } else if (type === 'website') {
-        let url = prompt('Enter website URL (https:// optional)');
+        let url = prompt(t('home.enterWebsite', 'Enter website URL (https:// optional)'));
         if (!url) return;
         if (!/^https?:\/\//i.test(url)) url = 'https://' + url;
         try {
           const u = new URL(url);
-          const name = prompt('Enter name') || u.hostname;
+          const name = prompt(t('home.enterName', 'Enter name')) || u.hostname;
           const icon = `https://www.google.com/s2/favicons?sz=64&domain=${u.hostname}`;
           favoriteApps.push({ url: u.href, name, icon });
         } catch (e) {
-          alert('Invalid URL');
+          alert(t('home.invalidURL', 'Invalid URL'));
           return;
         }
       } else if (['call','text','email'].includes(type)) {
-        const value = prompt(type === 'email' ? 'Enter email address' : 'Enter phone number');
+        const value = prompt(type === 'email' ? t('home.enterEmail', 'Enter email address') : t('home.enterPhone', 'Enter phone number'));
         if (!value) return;
-        const name = prompt('Enter name') || value;
+        const name = prompt(t('home.enterName', 'Enter name')) || value;
         favoriteApps.push({ type, value, name });
       } else {
-        alert('Unknown option');
+        alert(t('home.unknownOption', 'Unknown option'));
         return;
       }
       saveFavorites();
@@ -411,8 +412,8 @@
       if (cards.length === 0) {
         container.innerHTML = `
           <div class="empty-state">
-            <p>No data yet</p>
-            <button class="action">Add Info</button>
+            <p>${t('home.noData', 'No data yet')}</p>
+            <button class="action">${t('home.addInfo', 'Add Info')}</button>
           </div>`;
         return;
       }
@@ -426,15 +427,15 @@
       const container = document.getElementById('card-container');
       container.innerHTML += `
         <div class="error-card">
-          <p>${ERROR_MESSAGES[type]}</p>
-          <button onclick="fix_${type}()">Fix This</button>
+          <p>${ERROR_MESSAGES[type]()}</p>
+          <button onclick="fix_${type}()">${t('home.fixThis', 'Fix This')}</button>
         </div>`;
     }
 
-    function fix_location_denied() { showToast('Requesting location…'); }
-    function fix_storage_full() { showToast('Opening settings…'); }
-    function fix_offline() { showToast('Retrying…'); }
-    function fix_qr_invalid() { showToast('Generating new QR…'); }
+    function fix_location_denied() { showToast(t('home.requestingLocation', 'Requesting location…')); }
+    function fix_storage_full() { showToast(t('home.openingSettings', 'Opening settings…')); }
+    function fix_offline() { showToast(t('home.retrying', 'Retrying…')); }
+    function fix_qr_invalid() { showToast(t('home.generatingQR', 'Generating new QR…')); }
 
 
     function initHome() {

--- a/index.html
+++ b/index.html
@@ -3848,58 +3848,6 @@ Generated: ${new Date().toLocaleString()}`;
         });
     </script>
 
-    <script>
-        const languageBtn = document.getElementById('language-btn');
-        const languageMenu = document.getElementById('language-menu');
-        if (languageBtn && languageMenu) {
-            languageBtn.addEventListener('click', () => {
-                languageMenu.classList.toggle('show');
-            });
-            document.querySelectorAll('.lang-option').forEach(btn => {
-                btn.addEventListener('click', () => {
-                    setLanguage(btn.dataset.lang);
-                    languageMenu.classList.remove('show');
-                });
-            });
-        }
-        let translations = {};
-        fetch('TRANSLATION_TERMS.md')
-            .then(resp => resp.text())
-            .then(text => {
-                try {
-                    translations = JSON.parse(text);
-                } catch (e) {
-                    console.error('Failed to parse translations:', e);
-                }
-            })
-            .catch(err => {
-                console.error('Failed to load translations:', err);
-            })
-            .finally(() => {
-                const saved = localStorage.getItem('language') || 'en';
-                setLanguage(saved);
-            });
-
-        function setLanguage(lang) {
-            const dict = translations[lang] || {};
-            document.documentElement.lang = lang;
-            localStorage.setItem('language', lang);
-            document.querySelectorAll('.lang-option').forEach(btn => {
-                btn.classList.toggle('active', btn.dataset.lang === lang);
-            });
-            document.querySelectorAll('[data-i18n]').forEach(el => {
-                const parts = el.dataset.i18n.split('.');
-                let text = dict;
-                parts.forEach(k => { if (text) text = text[k]; });
-                if (text) el.textContent = text;
-            });
-            document.querySelectorAll('[data-i18n-aria]').forEach(el => {
-                const parts = el.dataset.i18nAria.split('.');
-                let text = dict;
-                parts.forEach(k => { if (text) text = text[k]; });
-                if (text) el.setAttribute('aria-label', text);
-            });
-        }
-    </script>
+    <script src="scripts/translate.js"></script>
 </body>
 </html>

--- a/invite.html
+++ b/invite.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ICS Event Generator - Proton Calendar Compatible</title>
+    <title data-i18n="invite.title">ICS Event Generator - Proton Calendar Compatible</title>
+    <script src="scripts/translate.js"></script>
     <style>
         * {
             margin: 0;
@@ -183,62 +184,62 @@
 <body>
     <div class="widget-container">
         <div class="widget-header">
-            <h1>📅 ICS Event Generator</h1>
-            <p>Create and email calendar invites</p>
+            <h1 data-i18n="invite.header">📅 ICS Event Generator</h1>
+            <p data-i18n="invite.subtitle">Create and email calendar invites</p>
         </div>
         <div class="widget-body">
             <div id="instructionMessage" class="instruction-message">
-                <h4>📧 Please complete these steps:</h4>
+                <h4 data-i18n="invite.instructions">📧 Please complete these steps:</h4>
                 <ol>
-                    <li>Your email client has opened with the invite details</li>
-                    <li>The ICS file "<span id="fileName"></span>" has been downloaded</li>
-                    <li>Attach the downloaded ICS file to your email</li>
-                    <li>Send the email to invite attendees</li>
+                    <li data-i18n="invite.step1">Your email client has opened with the invite details</li>
+                    <li data-i18n="invite.step2">The ICS file "<span id="fileName"></span>" has been downloaded</li>
+                    <li data-i18n="invite.step3">Attach the downloaded ICS file to your email</li>
+                    <li data-i18n="invite.step4">Send the email to invite attendees</li>
                 </ol>
-                <button type="button" class="btn btn-secondary" onclick="goHome()" style="margin-top:10px;">⬅️ Back to Main Screen</button>
+                <button type="button" class="btn btn-secondary" onclick="goHome()" style="margin-top:10px;" data-i18n="invite.backToMain">⬅️ Back to Main Screen</button>
             </div>
             <form id="eventForm">
                 <div class="form-group">
-                    <label for="title">Event Title *</label>
-                    <input type="text" id="title" required>
+                    <label for="title" data-i18n="invite.eventTitle">Event Title *</label>
+                    <input type="text" id="title" required data-i18n-placeholder="placeholders.eventTitle">
                 </div>
                 <div class="form-group">
-                    <label for="location">Location</label>
-                    <input type="text" id="location">
+                    <label for="location" data-i18n="invite.location">Location</label>
+                    <input type="text" id="location" data-i18n-placeholder="placeholders.location">
                 </div>
                 <div class="form-group">
-                    <label for="date">Date *</label>
+                    <label for="date" data-i18n="invite.date">Date *</label>
                     <input type="date" id="date" required>
                 </div>
                 <div class="form-row">
                     <div class="form-group">
-                        <label for="time">Start Time *</label>
+                        <label for="time" data-i18n="invite.startTime">Start Time *</label>
                         <input type="time" id="time" required>
                     </div>
                     <div class="form-group">
-                        <label for="endTime">End Time *</label>
+                        <label for="endTime" data-i18n="invite.endTime">End Time *</label>
                         <input type="time" id="endTime" required>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="organizer">Your Email (organizer) *</label>
-                    <input type="email" id="organizer" placeholder="your-email@proton.me" required>
+                    <label for="organizer" data-i18n="invite.organizerEmail">Your Email (organizer) *</label>
+                    <input type="email" id="organizer" placeholder="your-email@proton.me" required data-i18n-placeholder="placeholders.organizerEmail">
                 </div>
                 <div class="form-group">
-                    <label for="clientEmail">Client Proton Email *</label>
-                    <input type="email" id="clientEmail" readonly>
+                    <label for="clientEmail" data-i18n="invite.clientEmail">Client Proton Email *</label>
+                    <input type="email" id="clientEmail" readonly data-i18n-placeholder="placeholders.email">
                 </div>
                 <div class="form-group">
-                    <label for="attendees">Additional Attendee Emails (comma-separated)</label>
-                    <input type="text" id="attendees" placeholder="attendee1@example.com, attendee2@example.com">
+                    <label for="attendees" data-i18n="invite.additionalEmails">Additional Attendee Emails (comma-separated)</label>
+                    <input type="text" id="attendees" placeholder="attendee1@example.com, attendee2@example.com" data-i18n-placeholder="placeholders.additionalEmails">
                 </div>
                 <div class="form-group">
-                    <label for="description">Description</label>
+                    <label for="description" data-i18n="invite.description">Description</label>
                     <textarea id="description"></textarea>
                 </div>
-                <button type="button" class="btn btn-primary" onclick="sendEmailOnly()">📧 Send Email Only</button>
-                <button type="button" class="btn btn-primary" onclick="generateAndEmail()">📅 Create Invite & Email</button>
-                <button type="button" class="btn btn-secondary" onclick="resetForm()">Clear Form</button>
+                <button type="button" class="btn btn-primary" onclick="sendEmailOnly()" data-i18n="invite.sendEmailOnly">📧 Send Email Only</button>
+                <button type="button" class="btn btn-primary" onclick="generateAndEmail()" data-i18n="invite.createInviteEmail">📅 Create Invite & Email</button>
+                <button type="button" class="btn btn-secondary" onclick="resetForm()" data-i18n="invite.clearForm">Clear Form</button>
             </form>
         </div>
     </div>

--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -1,0 +1,60 @@
+const translations = {};
+function loadTranslations() {
+  return fetch('TRANSLATION_TERMS.md')
+    .then(resp => resp.text())
+    .then(text => {
+      try {
+        Object.assign(translations, JSON.parse(text));
+      } catch (e) {
+        console.error('Failed to parse translations:', e);
+      }
+    })
+    .catch(err => {
+      console.error('Failed to load translations:', err);
+    })
+    .finally(() => {
+      const saved = localStorage.getItem('language') || 'en';
+      setLanguage(saved);
+    });
+}
+
+function t(key, fallback = '') {
+  const lang = document.documentElement.lang || 'en';
+  const dict = translations[lang] || {};
+  let text = dict;
+  key.split('.').forEach(k => { if (text) text = text[k]; });
+  return text || fallback;
+}
+
+function setLanguage(lang) {
+  document.documentElement.lang = lang;
+  localStorage.setItem('language', lang);
+  document.querySelectorAll('.lang-option').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.lang === lang);
+  });
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = t(el.dataset.i18n, el.textContent);
+  });
+  document.querySelectorAll('[data-i18n-aria]').forEach(el => {
+    el.setAttribute('aria-label', t(el.dataset.i18nAria, el.getAttribute('aria-label') || ''));
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.setAttribute('placeholder', t(el.dataset.i18nPlaceholder, el.getAttribute('placeholder') || ''));
+  });
+}
+
+const languageBtn = document.getElementById('language-btn');
+const languageMenu = document.getElementById('language-menu');
+if (languageBtn && languageMenu) {
+  languageBtn.addEventListener('click', () => {
+    languageMenu.classList.toggle('show');
+  });
+  document.querySelectorAll('.lang-option').forEach(btn => {
+    btn.addEventListener('click', () => {
+      setLanguage(btn.dataset.lang);
+      languageMenu.classList.remove('show');
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadTranslations);


### PR DESCRIPTION
## Summary
- Move translation logic into reusable script with placeholder support
- Wire translation helper into site pages and mark text for i18n
- Replace hard-coded strings in app pages with `t()` lookups for translatability

## Testing
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_b_68c376bed5708332800eb4e8db11c313