### PR TITLE
Avoid clipping QR in modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,8 +814,9 @@
             background: white;
             padding: 20px;
             border-radius: var(--radius);
-            width: 90%;
-            max-width: 320px;
+            width: 400px;
+            max-width: none;
+            overflow: visible;
             box-shadow: var(--shadow-lg);
             text-align: center;
         }


### PR DESCRIPTION
## Summary
- widen modal container so QR code displays fully

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c399f1312c8332989329e7956a29a5