### PR TITLE
feat: add complete FAQ page accessible via settings

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,1012 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>iKey Personal Hub - Complete FAQ Guide</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .header {
+            text-align: center;
+            color: white;
+            margin-bottom: 30px;
+            animation: fadeInDown 0.8s ease;
+        }
+
+        .header h1 {
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+            text-shadow: 2px 2px 4px rgba(0,0,0,0.2);
+        }
+
+        .header p {
+            font-size: 1.1rem;
+            opacity: 0.95;
+            max-width: 800px;
+            margin: 0 auto;
+            line-height: 1.6;
+        }
+
+        .security-tiers {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+            animation: fadeIn 0.8s ease;
+            max-width: 700px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .tier-card {
+            background: white;
+            border-radius: 12px;
+            padding: 25px;
+            text-align: center;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+            transition: transform 0.3s ease;
+        }
+
+        .tier-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+        }
+
+        .tier-icon {
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+        }
+
+        .tier-name {
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 8px;
+            font-size: 1.1rem;
+        }
+
+        .tier-desc {
+            font-size: 0.9rem;
+            color: #666;
+            line-height: 1.4;
+        }
+
+        .search-container {
+            background: white;
+            border-radius: 20px;
+            padding: 20px;
+            margin-bottom: 25px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.15);
+            animation: fadeInUp 0.8s ease;
+        }
+
+        .search-input {
+            width: 100%;
+            padding: 15px 20px;
+            font-size: 1.1rem;
+            border: 2px solid #e0e0e0;
+            border-radius: 12px;
+            transition: all 0.3s ease;
+        }
+
+        .search-input:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        }
+
+        .suggestions {
+            margin-top: 15px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .suggestion-chip {
+            padding: 8px 16px;
+            background: linear-gradient(135deg, #667eea, #764ba2);
+            color: white;
+            border-radius: 20px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            font-size: 0.9rem;
+            border: none;
+            animation: slideIn 0.3s ease;
+        }
+
+        .suggestion-chip:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+        }
+
+        .stats {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+            margin: 20px 0;
+            animation: fadeIn 1s ease;
+        }
+
+        .stat-item {
+            background: white;
+            padding: 15px 25px;
+            border-radius: 12px;
+            box-shadow: 0 3px 15px rgba(0,0,0,0.1);
+            text-align: center;
+        }
+
+        .stat-value {
+            font-size: 1.5rem;
+            font-weight: bold;
+            color: #667eea;
+        }
+
+        .stat-label {
+            font-size: 0.9rem;
+            color: #666;
+            margin-top: 5px;
+        }
+
+        .categories-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 12px;
+            margin-bottom: 25px;
+            animation: fadeIn 1s ease;
+        }
+
+        .category-card {
+            background: white;
+            border-radius: 12px;
+            padding: 15px;
+            text-align: center;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            box-shadow: 0 3px 15px rgba(0,0,0,0.1);
+        }
+
+        .category-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+        }
+
+        .category-card.active {
+            background: linear-gradient(135deg, #667eea, #764ba2);
+            color: white;
+        }
+
+        .category-icon {
+            font-size: 1.8rem;
+            margin-bottom: 8px;
+        }
+
+        .category-name {
+            font-weight: 600;
+            font-size: 0.9rem;
+        }
+
+        .faq-container {
+            background: white;
+            border-radius: 20px;
+            padding: 30px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.15);
+            max-height: 700px;
+            overflow-y: auto;
+            animation: fadeInUp 0.8s ease;
+        }
+
+        .faq-item {
+            margin-bottom: 20px;
+            padding: 0;
+            background: white;
+            border-radius: 16px;
+            transition: all 0.3s ease;
+            cursor: pointer;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+            border: 2px solid #f0f2ff;
+            overflow: hidden;
+        }
+
+        .faq-item:hover {
+            box-shadow: 0 8px 25px rgba(102, 126, 234, 0.15);
+            border-color: #667eea;
+            transform: translateY(-3px);
+        }
+
+        .faq-item.highlighted {
+            background: linear-gradient(135deg, rgba(102, 126, 234, 0.05), rgba(118, 75, 162, 0.05));
+            border-color: #764ba2;
+            box-shadow: 0 8px 25px rgba(118, 75, 162, 0.2);
+            animation: pulse 0.5s ease;
+        }
+
+        .faq-header {
+            padding: 25px 30px;
+            background: linear-gradient(135deg, #f8f9fa, #f0f2ff);
+            position: relative;
+            transition: background 0.3s ease;
+        }
+
+        .faq-item:hover .faq-header {
+            background: linear-gradient(135deg, #f0f2ff, #e8ecff);
+        }
+
+        .faq-item.highlighted .faq-header {
+            background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.1));
+        }
+
+        .faq-question {
+            font-weight: 600;
+            color: #2d3748;
+            font-size: 1.15rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            line-height: 1.4;
+            padding-right: 40px;
+        }
+
+        .faq-meta {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-top: 12px;
+            flex-wrap: wrap;
+        }
+
+        .category-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            background: white;
+            border-radius: 20px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #667eea;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+        }
+
+        .category-badge-icon {
+            font-size: 1rem;
+        }
+
+        .faq-answer {
+            color: #4a5568;
+            line-height: 1.8;
+            font-size: 1rem;
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.4s ease;
+            background: white;
+        }
+
+        .faq-answer-content {
+            padding: 0 30px 25px 30px;
+        }
+
+        .faq-answer.open {
+            max-height: 800px;
+        }
+
+        .expand-icon {
+            position: absolute;
+            right: 25px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 36px;
+            height: 36px;
+            background: white;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.3s ease;
+            color: #667eea;
+            font-size: 1.2rem;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        .expand-icon:hover {
+            background: #667eea;
+            color: white;
+            transform: translateY(-50%) scale(1.1);
+        }
+
+        .expand-icon.open {
+            transform: translateY(-50%) rotate(180deg);
+        }
+
+        .expand-icon.open:hover {
+            transform: translateY(-50%) rotate(180deg) scale(1.1);
+        }
+
+        .match-score {
+            display: inline-flex;
+            align-items: center;
+            padding: 6px 12px;
+            background: linear-gradient(135deg, #667eea, #764ba2);
+            color: white;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+        }
+
+        .answer-highlight {
+            background: linear-gradient(90deg, #667eea, #764ba2);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            font-weight: 600;
+            font-size: 0.9rem;
+            margin-bottom: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .code-block {
+            background: #f4f4f4;
+            border-left: 3px solid #667eea;
+            padding: 10px;
+            margin: 10px 0;
+            font-family: monospace;
+            font-size: 0.9rem;
+            overflow-x: auto;
+        }
+
+        .no-results {
+            text-align: center;
+            padding: 40px;
+            color: #999;
+            font-size: 1.1rem;
+        }
+
+        @keyframes fadeInDown {
+            from { opacity: 0; transform: translateY(-20px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        @keyframes fadeInUp {
+            from { opacity: 0; transform: translateY(20px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        @keyframes slideIn {
+            from { opacity: 0; transform: translateX(-10px); }
+            to { opacity: 1; transform: translateX(0); }
+        }
+
+        @keyframes pulse {
+            0%, 100% { transform: scale(1); }
+            50% { transform: scale(1.02); }
+        }
+
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        ::-webkit-scrollbar-track {
+            background: #f1f1f1;
+            border-radius: 10px;
+        }
+
+        ::-webkit-scrollbar-thumb {
+            background: linear-gradient(135deg, #667eea, #764ba2);
+            border-radius: 10px;
+        }
+
+        @media (max-width: 768px) {
+            .header h1 { font-size: 1.8rem; }
+            .categories-grid { grid-template-columns: repeat(auto-fit, minmax(100px, 1fr)); }
+            .category-card { padding: 12px; }
+            .category-icon { font-size: 1.5rem; }
+            .stats { flex-direction: column; gap: 15px; }
+            .faq-question { font-size: 1rem; }
+            .expand-icon { right: 15px; }
+            .faq-header { padding: 20px; }
+            .faq-answer-content { padding: 0 20px 20px 20px; }
+            .security-tiers { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🔐 iKey Personal Hub FAQ</h1>
+            <p>Client-side encrypted personal information hub with emergency QR access. Store any files securely while maintaining quick access to your favorite privacy tools and services.</p>
+        </div>
+
+        <div class="security-tiers">
+            <div class="tier-card">
+                <div class="tier-icon">🔓</div>
+                <div class="tier-name">Public Tier</div>
+                <div class="tier-desc">Emergency info accessible via QR code - contact details and critical information without password</div>
+            </div>
+            <div class="tier-card">
+                <div class="tier-icon">🔐</div>
+                <div class="tier-name">Password-Protected Tier</div>
+                <div class="tier-desc">Your personal files, documents, and sensitive information - secured with encryption</div>
+            </div>
+        </div>
+
+        <div class="stats">
+            <div class="stat-item">
+                <div class="stat-value" id="totalQuestions">0</div>
+                <div class="stat-label">Total Questions</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-value" id="matchedResults">0</div>
+                <div class="stat-label">Matched Results</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-value" id="selectedCategory">All Topics</div>
+                <div class="stat-label">Selected</div>
+            </div>
+        </div>
+
+        <div class="search-container">
+            <input type="text" 
+                   class="search-input" 
+                   id="searchInput" 
+                   placeholder="Type your question (e.g., 'bookmarks', 'proton apps', 'QR code', 'encryption')">
+            <div class="suggestions" id="suggestions"></div>
+        </div>
+
+        <div class="categories-grid" id="categoriesGrid"></div>
+
+        <div class="faq-container" id="faqContainer">
+            <div class="no-results">Start typing to search or select a category above</div>
+        </div>
+    </div>
+
+    <script>
+        // Complete FAQ Database for iKey Personal Hub
+        const faqData = [
+            // Getting Started
+            {
+                category: 'Getting Started',
+                question: 'What is iKey and what can I use it for?',
+                answer: 'iKey is your personal encrypted hub that combines secure file storage with a customizable app launcher. Store any personal information, documents, or files you want protected, while keeping your favorite apps and services at your fingertips. It\'s entirely up to you - use it for medical records, financial documents, passwords, personal notes, or any sensitive information you need encrypted and accessible.',
+                keywords: ['what is', 'ikey', 'purpose', 'use for', 'overview']
+            },
+            {
+                category: 'Getting Started',
+                question: 'How do I start using iKey?',
+                answer: 'Just visit the web app - no account needed! The setup wizard walks you through: entering basic info for your emergency QR code (optional), setting a strong password for encrypted storage, and customizing your home screen with favorite apps. The app generates a unique GUID stored locally. To start completely fresh, add ?setup=new to the URL.',
+                keywords: ['start', 'setup', 'begin', 'first time', 'new user']
+            },
+            {
+                category: 'Getting Started',
+                question: 'What are the two security tiers?',
+                answer: 'Public Tier (Gray 🔓): Basic info accessible via QR code without a password - perfect for emergency contacts or information you want easily shareable. Password-Protected Tier (Blue 🔐): Everything else - your personal files, documents, notes, or any sensitive information. You decide what goes where based on your needs.',
+                keywords: ['tiers', 'security levels', 'public', 'protected', 'two tier']
+            },
+            {
+                category: 'Getting Started',
+                question: 'Do I need accounts for iKey or Proton services?',
+                answer: 'No account needed for iKey itself - it runs entirely in your browser. For Proton services, you\'ll want to create a free Proton account to access their encrypted email, drive, VPN, and other privacy tools. iKey makes it easy to access all Proton services from one place, but using them is entirely optional.',
+                keywords: ['account', 'registration', 'proton account', 'sign up']
+            },
+
+            // Home Screen & Bookmarks
+            {
+                category: 'Bookmarks',
+                question: 'How does the home screen bookmark system work?',
+                answer: 'The home screen is your personal launcher with a customizable grid of bookmarks. Tap any bookmark once to launch it. To edit: long-press any bookmark until icons start shaking (edit mode), tap the X to remove bookmarks, tap the + tile to add new ones, drag bookmarks to reorder them, tap Done when finished. The grid automatically adjusts to fit your screen.',
+                keywords: ['bookmarks', 'home screen', 'launcher', 'grid', 'favorites']
+            },
+            {
+                category: 'Bookmarks',
+                question: 'What types of bookmarks can I add?',
+                answer: 'Four types available: Website bookmarks (any URL), Built-in tools (Weather, Police Dispatch, etc.), Direct contact shortcuts (call/text/email specific people), and Proton service shortcuts (Mail, Drive, VPN, Pass, etc.). Mix and match based on what you need quick access to.',
+                keywords: ['bookmark types', 'add bookmark', 'website', 'contact', 'shortcuts']
+            },
+            {
+                category: 'Bookmarks',
+                question: 'How do I add all Proton apps at once?',
+                answer: 'When adding a bookmark, select "Add All Proton Apps" to instantly add shortcuts for Proton Mail, Drive, VPN, Pass, Calendar, and SimpleLogin. They\'ll appear with official icons and launch directly to each service. You can remove individual ones you don\'t use or reorder them as needed.',
+                keywords: ['proton apps', 'add all', 'proton services', 'bulk add']
+            },
+            {
+                category: 'Bookmarks',
+                question: 'Can I create contact shortcuts for quick calling/texting?',
+                answer: 'Yes! Add a bookmark and choose "Contact Shortcut". Enter the person\'s name, phone/email, optional description, and photo. When tapped, it launches your device\'s default app - phone for calls, messages for texts, email client for emails. Perfect for emergency contacts, doctors, or frequently contacted people.',
+                keywords: ['contact shortcut', 'call', 'text', 'email', 'direct dial', 'quick contact']
+            },
+            {
+                category: 'Bookmarks',
+                question: 'How do I customize bookmark appearance?',
+                answer: 'For websites, iKey automatically fetches the site\'s favicon. For contacts, you can add a photo that displays as the icon. Built-in tools and Proton services use their official icons. In edit mode, drag bookmarks to any position. The grid auto-adjusts between 3-5 columns based on screen size.',
+                keywords: ['customize', 'icons', 'appearance', 'favicon', 'photos', 'layout']
+            },
+            {
+                category: 'Bookmarks',
+                question: 'Are my bookmarks backed up or synced?',
+                answer: 'Important: Bookmarks are stored ONLY in your browser\'s local storage - they\'re not encrypted or backed up. If you clear browser data or lose your device, bookmarks are gone. For important shortcuts, manually note the details elsewhere (like in an encrypted note in Proton Drive). Bookmarks are for convenience, not critical data storage.',
+                keywords: ['bookmark backup', 'sync bookmarks', 'save bookmarks', 'restore']
+            },
+            {
+                category: 'Bookmarks',
+                question: 'Can I have different bookmark sets for different uses?',
+                answer: 'Yes! Use URL hashes to create separate profiles. Example: site.com/ikey#work for work bookmarks, site.com/ikey#personal for personal bookmarks, site.com/ikey#family for family-related shortcuts. Each hash maintains completely separate bookmark sets and encrypted data.',
+                keywords: ['multiple profiles', 'bookmark sets', 'separate', 'work personal']
+            },
+
+            // Proton Integration
+            {
+                category: 'Proton Suite',
+                question: 'How does iKey work with Proton services?',
+                answer: 'iKey serves as a convenient launcher for the entire Proton privacy suite. Add shortcuts to quickly access Proton Mail (encrypted email), Drive (encrypted cloud storage), VPN (secure browsing), Pass (password manager), Calendar (encrypted scheduling), and SimpleLogin (email aliases). Each service maintains its own encryption - iKey just makes accessing them easier.',
+                keywords: ['proton integration', 'proton services', 'how proton works', 'suite']
+            },
+            {
+                category: 'Proton Suite',
+                question: 'How do Proton services work together?',
+                answer: 'Proton services share single sign-on - one account accesses all services. They share encrypted storage quota (Mail, Drive, Calendar combined). Pass integrates with SimpleLogin for email aliases. Calendar integrates with Mail for invites. VPN protects all services when active. It\'s a complete privacy ecosystem you can use however fits your needs.',
+                keywords: ['proton together', 'ecosystem', 'integration', 'how services work']
+            },
+            {
+                category: 'Proton Suite',
+                question: 'What can I store in Proton Drive from iKey?',
+                answer: 'Anything you want encrypted in the cloud! Export your iKey data as JSON and save to Proton Drive. Store documents, photos, backups, notes - all encrypted. Create folders for organization. Share files securely with expiring links. Think of it as your encrypted Dropbox that integrates with your iKey hub.',
+                keywords: ['proton drive', 'store files', 'cloud storage', 'encrypted files']
+            },
+            {
+                category: 'Proton Suite',
+                question: 'Do I need paid Proton plans?',
+                answer: 'Free tier is generous: 1GB email storage, 5GB Drive storage, VPN in 5 countries, basic Pass features. Paid plans add: 500GB+ storage, all VPN locations, unlimited email aliases, custom domains, priority support. Start free and upgrade if you need more. iKey works with both free and paid accounts.',
+                keywords: ['proton pricing', 'free vs paid', 'proton plans', 'costs']
+            },
+            {
+                category: 'Proton Suite',
+                question: 'Why use Proton instead of Google/Microsoft?',
+                answer: 'Proton offers true privacy: end-to-end encryption (they can\'t read your data), zero-access encryption (even under legal pressure), Swiss privacy laws (strict data protection), no ads or tracking, open-source code (auditable). You own your data, not the company. Perfect complement to iKey\'s local encryption.',
+                keywords: ['why proton', 'vs google', 'vs microsoft', 'privacy comparison']
+            },
+
+            // Security & Encryption
+            {
+                category: 'Security',
+                question: 'How does iKey encrypt my files and data?',
+                answer: 'Everything uses AES-256-GCM encryption (military-grade) via your browser\'s Web Crypto API. Your password goes through PBKDF2 key derivation (100,000 iterations) making it virtually uncrackable. All encryption happens locally in your browser - files never leave your device unencrypted. Even if someone gets your encrypted data, they can\'t read it without your exact password.',
+                keywords: ['encryption', 'aes-256', 'security', 'files encrypted', 'how secure']
+            },
+            {
+                category: 'Security',
+                question: 'What is zero-knowledge architecture?',
+                answer: 'Zero-knowledge means no server, developer, or third party can see your unencrypted files or data. Everything encrypts in your browser before any transmission. Even with cloud backup enabled, servers only receive encrypted blobs they cannot decrypt. Your password never leaves your device. Only you can access your information.',
+                keywords: ['zero knowledge', 'privacy', 'architecture', 'servers cant see']
+            },
+            {
+                category: 'Security',
+                question: 'Can I store sensitive documents safely?',
+                answer: 'Absolutely! The password-protected tier is designed for any sensitive information - financial documents, legal papers, medical records, passwords, personal notes, private photos. With AES-256 encryption, your files are safer than in most physical safes. Just remember: no password = no access, so keep it secure but memorable.',
+                keywords: ['sensitive documents', 'safe storage', 'financial', 'legal', 'private']
+            },
+            {
+                category: 'Security',
+                question: 'What if someone steals my device?',
+                answer: 'Your encrypted data remains protected even on a stolen device. Without your password, thieves cannot access any password-protected files or information. Only the basic QR code data (if you set it up) would be visible. Always use device-level security (PIN/biometrics) as an extra layer.',
+                keywords: ['stolen device', 'theft', 'lost phone', 'device security']
+            },
+
+            // QR Code System
+            {
+                category: 'QR Code',
+                question: 'What is the QR code for and do I need it?',
+                answer: 'The QR code is optional - it\'s for sharing basic information without a password. Use it for: emergency contacts (medical scenarios), business card info (networking), public contact details (easy sharing), or any info you want quickly accessible. You decide what goes in it, or skip it entirely if you just want encrypted storage.',
+                keywords: ['qr code', 'what is qr', 'need qr', 'qr purpose', 'optional']
+            },
+            {
+                category: 'QR Code',
+                question: 'What information can I put in the QR code?',
+                answer: 'Whatever you want publicly accessible: name and contact info, emergency contacts, medical allergies (if relevant), business details, social media handles, or a simple message. Keep it minimal - QR codes have size limits. Remember: anyone who scans sees this info, so don\'t include sensitive data.',
+                keywords: ['qr contents', 'qr information', 'what in qr', 'qr data']
+            },
+            {
+                category: 'QR Code',
+                question: 'How do I use the QR code for different purposes?',
+                answer: 'Emergency use: Include medical info and emergency contacts. Business use: Add professional contact details and LinkedIn. Personal use: Basic contact info for easy sharing. The QR is just a tool - adapt it to your needs or don\'t use it at all. You can update it anytime through the app.',
+                keywords: ['qr uses', 'qr purposes', 'emergency', 'business card', 'sharing']
+            },
+
+            // Password & Recovery
+            {
+                category: 'Password',
+                question: 'What happens if I forget my password?',
+                answer: 'Your password IS the encryption key - without it, your encrypted files are permanently inaccessible. This isn\'t a bug, it\'s maximum security. Always save the recovery key file (auto-downloaded during setup) in a secure place. No one, including iKey developers, can recover your data without your password.',
+                keywords: ['forgot password', 'lost password', 'recovery', 'cant access']
+            },
+            {
+                category: 'Password',
+                question: 'What is the recovery key file?',
+                answer: 'An encrypted backup key automatically downloaded when you set/change your password. Store it somewhere secure but accessible: USB drive in a safe, encrypted cloud storage, password manager attachment, or trusted person. It provides emergency access but only works from the original website URL.',
+                keywords: ['recovery key', 'key file', 'backup key', 'emergency access']
+            },
+            {
+                category: 'Password',
+                question: 'How do I create a strong but memorable password?',
+                answer: 'Use a passphrase combining random words: "correct-horse-battery-staple" is stronger than "P@ssw0rd123!" Or use a sentence: "My2Dogs&LoveChasing7Squirrels!" Consider a password manager for generation and storage. The app strengthens any password with 100,000 iterations of key derivation, but start strong.',
+                keywords: ['strong password', 'password tips', 'memorable', 'passphrase']
+            },
+
+            // Storage & Backup
+            {
+                category: 'Storage',
+                question: 'Where are my files and data stored?',
+                answer: 'Primary storage is in your browser\'s localStorage (encrypted on your device). Optional cloud backup sends encrypted copies to configured webhooks. Think of it as: localStorage = your vault, cloud backup = offsite safety deposit box. Both are encrypted, neither can be read without your password.',
+                keywords: ['storage', 'where stored', 'files location', 'localStorage']
+            },
+            {
+                category: 'Storage',
+                question: 'Should I enable cloud backup?',
+                answer: 'Yes, if you want protection against: device loss/theft, browser data clearing, hardware failure, or accidental deletion. Your data remains encrypted even in the cloud. Without backup, clearing browser data means losing everything. The choice is yours based on your security vs. convenience needs.',
+                keywords: ['cloud backup', 'should backup', 'enable sync', 'backup recommended']
+            },
+            {
+                category: 'Storage',
+                question: 'Can I use iKey on multiple devices?',
+                answer: 'Yes! With cloud sync: access from any device with your password. Without cloud sync: manually transfer via QR code or JSON export. Each device maintains its own copy. Use the same password across devices to decrypt your data. Perfect for phone + computer access.',
+                keywords: ['multiple devices', 'phone computer', 'sync devices', 'cross device']
+            },
+            {
+                category: 'Storage',
+                question: 'How do I backup everything?',
+                answer: 'Multiple backup strategies: Enable cloud sync (automatic), Export JSON file (manual backup), Save QR code URL (basic info), Screenshot important data, Store in Proton Drive (encrypted cloud), Keep recovery key file (password recovery). Use multiple methods for critical information.',
+                keywords: ['backup', 'how to backup', 'save everything', 'export data']
+            },
+
+            // Privacy
+            {
+                category: 'Privacy',
+                question: 'Does iKey track or collect my data?',
+                answer: 'Absolutely not. Zero tracking, no analytics, no cookies, no telemetry, no user accounts, no data collection. We literally don\'t know you exist. Your data stays on your device (or encrypted in your chosen cloud). This is true privacy - not even usage statistics.',
+                keywords: ['privacy', 'tracking', 'data collection', 'analytics', 'cookies']
+            },
+            {
+                category: 'Privacy',
+                question: 'Who can see my stored files and information?',
+                answer: 'Only you (with your password), anyone you explicitly share your password with, or anyone with your recovery file + correct URL. Not readable by: iKey developers, cloud storage providers, hackers who steal encrypted data, or government/legal requests. True zero-knowledge privacy.',
+                keywords: ['who can see', 'file access', 'privacy', 'visibility']
+            },
+            {
+                category: 'Privacy',
+                question: 'How private is this compared to cloud services?',
+                answer: 'More private than standard cloud storage: Google/Dropbox/OneDrive can technically access your files (and must comply with legal requests). iKey + Proton means end-to-end encryption - no one but you can decrypt. It\'s like having a personal safe vs. a bank safety deposit box.',
+                keywords: ['privacy comparison', 'vs google', 'vs dropbox', 'cloud privacy']
+            },
+
+            // Technical
+            {
+                category: 'Technical',
+                question: 'Can I self-host iKey?',
+                answer: 'Yes! It\'s a single HTML file - host anywhere: your own server, local computer (file://), GitHub Pages (free), Netlify/Vercel (free), or even IPFS (decentralized). Modify webhook URLs for your own backup infrastructure. No database or server-side code needed.',
+                keywords: ['self host', 'own server', 'hosting', 'deploy', 'installation']
+            },
+            {
+                category: 'Technical',
+                question: 'What browsers work with iKey?',
+                answer: 'Any modern browser: Chrome 60+, Firefox 57+, Safari 11+, Edge 79+. Mobile browsers fully supported. Requires Web Crypto API for encryption and localStorage for data. Older browsers may not support required encryption features. Works offline once loaded.',
+                keywords: ['browsers', 'compatibility', 'requirements', 'mobile', 'supported']
+            },
+            {
+                category: 'Technical',
+                question: 'Can I modify or customize iKey?',
+                answer: 'Absolutely! It\'s open source - modify anything: change the interface, add features, customize encryption, modify storage locations, integrate your services. It\'s a single HTML file with inline JavaScript and CSS. Fork it, modify it, make it yours.',
+                keywords: ['customize', 'modify', 'open source', 'fork', 'change code']
+            },
+
+            // Troubleshooting
+            {
+                category: 'Troubleshooting',
+                question: 'Bookmarks disappeared - what happened?',
+                answer: 'Bookmarks are stored only in browser localStorage (not encrypted/backed up). They disappear if you: cleared browser data, used a different browser, accessed from different device, or used a different URL hash (#work vs #personal). Unfortunately, they cannot be recovered. Document important shortcuts separately.',
+                keywords: ['bookmarks gone', 'lost bookmarks', 'disappeared', 'missing shortcuts']
+            },
+            {
+                category: 'Troubleshooting',
+                question: 'How do I start completely fresh?',
+                answer: 'Two ways: Add ?setup=new to the URL to force setup wizard (keeps existing data), or clear all browser data for the site (permanent deletion). For separate instances, use URL hashes: site.com#personal, site.com#work. Each hash is completely independent.',
+                keywords: ['start fresh', 'reset', 'new setup', 'clean slate', 'start over']
+            },
+            {
+                category: 'Troubleshooting',
+                question: 'Auto-save isn\'t working - what should I check?',
+                answer: 'Auto-save triggers 2 seconds after changes. Check: JavaScript enabled in browser? localStorage not full? Browser supports required features? Look for sync status in header. Try manual sync button in Security settings. Check browser console (F12) for error messages.',
+                keywords: ['auto save not working', 'sync issues', 'not saving', 'save problem']
+            },
+
+            // Best Practices
+            {
+                category: 'Best Practices',
+                question: 'What\'s the best way to organize my information?',
+                answer: 'Public tier: Only info you\'d put on a business card or medical bracelet. Password tier: Everything else - documents, passwords, notes, files. Use Proton Drive for large files or additional backups. Keep bookmarks for frequently accessed services. It\'s your system - organize however works for you.',
+                keywords: ['organize', 'best practices', 'information management', 'tips']
+            },
+            {
+                category: 'Best Practices',
+                question: 'How do I maximize both security and convenience?',
+                answer: 'Use a strong but memorable passphrase. Enable cloud backup for redundancy. Keep recovery key in secure location. Set up Proton services for additional encryption. Use bookmarks for quick access. Regular JSON exports for offline backup. Different URL hashes for different use cases.',
+                keywords: ['security convenience', 'best setup', 'optimal use', 'recommendations']
+            },
+            {
+                category: 'Best Practices',
+                question: 'What should I definitely NOT store in iKey?',
+                answer: 'Never store: cryptocurrency private keys (use hardware wallet), passwords in plain text in public tier, illegal content, massive files (use Proton Drive instead), critical data without backup. Remember: public tier = anyone can see, password tier = only you can see.',
+                keywords: ['dont store', 'not recommended', 'avoid storing', 'warnings']
+            }
+        ];
+
+        // Rest of the JavaScript code remains the same...
+        // Fuzzy string matching function
+        function fuzzyMatch(text, query) {
+            text = text.toLowerCase();
+            query = query.toLowerCase();
+            
+            // Exact match gets highest score
+            if (text.includes(query)) return 1.0;
+            
+            // Word-by-word matching
+            const queryWords = query.split(/\s+/);
+            const textWords = text.split(/\s+/);
+            let matchCount = 0;
+            
+            for (const qWord of queryWords) {
+                for (const tWord of textWords) {
+                    if (tWord.includes(qWord) || qWord.includes(tWord)) {
+                        matchCount++;
+                        break;
+                    }
+                }
+            }
+            
+            if (matchCount > 0) {
+                return matchCount / queryWords.length * 0.8;
+            }
+            
+            // Character-level fuzzy matching
+            let score = 0;
+            let lastIndex = -1;
+            
+            for (const char of query) {
+                const index = text.indexOf(char, lastIndex + 1);
+                if (index > -1) {
+                    score++;
+                    lastIndex = index;
+                }
+            }
+            
+            return (score / query.length) * 0.5;
+        }
+
+        // Search function
+        function searchFAQ(query, selectedCategory = null) {
+            if (!query || query.length < 2) return [];
+            
+            const results = faqData
+                .filter(item => !selectedCategory || item.category === selectedCategory)
+                .map(item => {
+                    // Calculate match scores
+                    const questionScore = fuzzyMatch(item.question, query) * 1.5;
+                    const keywordScore = Math.max(...item.keywords.map(k => fuzzyMatch(k, query))) * 2;
+                    const answerScore = fuzzyMatch(item.answer, query) * 0.8;
+                    const categoryScore = fuzzyMatch(item.category, query) * 0.5;
+                    
+                    const totalScore = Math.max(questionScore, keywordScore, answerScore, categoryScore);
+                    
+                    return { ...item, score: totalScore };
+                })
+                .filter(item => item.score > 0.3)
+                .sort((a, b) => b.score - a.score)
+                .slice(0, 15);
+            
+            return results;
+        }
+
+        // Initialize categories
+        const categories = [
+            { name: 'Getting Started', icon: '🚀' },
+            { name: 'Bookmarks', icon: '🔖' },
+            { name: 'Proton Suite', icon: '🔐' },
+            { name: 'Security', icon: '🔒' },
+            { name: 'QR Code', icon: '📱' },
+            { name: 'Password', icon: '🔑' },
+            { name: 'Storage', icon: '💾' },
+            { name: 'Privacy', icon: '🛡️' },
+            { name: 'Technical', icon: '⚙️' },
+            { name: 'Troubleshooting', icon: '🔧' },
+            { name: 'Best Practices', icon: '✅' }
+        ];
+
+        let selectedCategory = null;
+        let currentResults = [];
+
+        // Common search suggestions
+        const suggestions = [
+            'bookmark system',
+            'proton apps',
+            'contact shortcuts',
+            'encryption',
+            'cloud backup',
+            'QR code',
+            'password tips',
+            'self-host'
+        ];
+
+        // Render categories grid
+        function renderCategories() {
+            const grid = document.getElementById('categoriesGrid');
+            grid.innerHTML = categories.map(cat => `
+                <div class="category-card" data-category="${cat.name}">
+                    <div class="category-icon">${cat.icon}</div>
+                    <div class="category-name">${cat.name}</div>
+                </div>
+            `).join('');
+            
+            // Add click handlers
+            grid.querySelectorAll('.category-card').forEach(card => {
+                card.addEventListener('click', () => {
+                    // Toggle selection
+                    if (card.classList.contains('active')) {
+                        card.classList.remove('active');
+                        selectedCategory = null;
+                        document.getElementById('selectedCategory').textContent = 'All Topics';
+                    } else {
+                        grid.querySelectorAll('.category-card').forEach(c => c.classList.remove('active'));
+                        card.classList.add('active');
+                        selectedCategory = card.dataset.category;
+                        document.getElementById('selectedCategory').textContent = selectedCategory;
+                    }
+                    
+                    // Re-run search if there's a query
+                    const query = document.getElementById('searchInput').value;
+                    if (query) {
+                        performSearch(query);
+                    } else {
+                        // Show all questions from selected category
+                        showCategoryQuestions(selectedCategory);
+                    }
+                });
+            });
+        }
+
+        // Show all questions from a category
+        function showCategoryQuestions(category) {
+            if (!category) {
+                document.getElementById('faqContainer').innerHTML = '<div class="no-results">Select a category to view questions</div>';
+                return;
+            }
+            
+            const questions = faqData.filter(item => item.category === category);
+            renderResults(questions.map(q => ({ ...q, score: 1 })));
+        }
+
+        // Render suggestions
+        function renderSuggestions() {
+            const container = document.getElementById('suggestions');
+            container.innerHTML = suggestions.map(s => 
+                `<button class="suggestion-chip" onclick="searchFromSuggestion('${s}')">${s}</button>`
+            ).join('');
+        }
+
+        // Search from suggestion
+        function searchFromSuggestion(query) {
+            document.getElementById('searchInput').value = query;
+            performSearch(query);
+        }
+
+        // Get category icon
+        function getCategoryIcon(categoryName) {
+            const cat = categories.find(c => c.name === categoryName);
+            return cat ? cat.icon : '📋';
+        }
+
+        // Render FAQ results
+        function renderResults(results) {
+            const container = document.getElementById('faqContainer');
+            
+            if (results.length === 0) {
+                container.innerHTML = '<div class="no-results">No matching questions found. Try different keywords.</div>';
+                document.getElementById('matchedResults').textContent = '0';
+                return;
+            }
+            
+            document.getElementById('matchedResults').textContent = results.length;
+            
+            container.innerHTML = results.map((item, index) => `
+                <div class="faq-item ${item.score > 0.8 ? 'highlighted' : ''}" data-index="${index}">
+                    <div class="faq-header">
+                        <div class="faq-question">
+                            <span>${item.question}</span>
+                        </div>
+                        <div class="faq-meta">
+                            <div class="category-badge">
+                                <span class="category-badge-icon">${getCategoryIcon(item.category)}</span>
+                                <span>${item.category}</span>
+                            </div>
+                            ${item.score < 1 ? `<span class="match-score">⭐ ${Math.round(item.score * 100)}% match</span>` : ''}
+                        </div>
+                        <span class="expand-icon">▼</span>
+                    </div>
+                    <div class="faq-answer">
+                        <div class="faq-answer-content">
+                            <div class="answer-highlight">Answer</div>
+                            ${item.answer}
+                        </div>
+                    </div>
+                </div>
+            `).join('');
+            
+            // Add click handlers for expand/collapse
+            container.querySelectorAll('.faq-item').forEach(item => {
+                item.addEventListener('click', (e) => {
+                    if (e.target.tagName === 'A' || e.target.tagName === 'BUTTON') return;
+                    
+                    const answer = item.querySelector('.faq-answer');
+                    const icon = item.querySelector('.expand-icon');
+                    
+                    // Close all other items
+                    container.querySelectorAll('.faq-item').forEach(otherItem => {
+                        if (otherItem !== item) {
+                            otherItem.querySelector('.faq-answer').classList.remove('open');
+                            otherItem.querySelector('.expand-icon').classList.remove('open');
+                        }
+                    });
+                    
+                    // Toggle current item
+                    answer.classList.toggle('open');
+                    icon.classList.toggle('open');
+                });
+            });
+        }
+
+        // Perform search
+        function performSearch(query) {
+            currentResults = searchFAQ(query, selectedCategory);
+            renderResults(currentResults);
+        }
+
+        // Initialize
+        document.addEventListener('DOMContentLoaded', () => {
+            renderCategories();
+            renderSuggestions();
+            
+            // Set up search input
+            const searchInput = document.getElementById('searchInput');
+            let searchTimeout;
+            
+            searchInput.addEventListener('input', (e) => {
+                clearTimeout(searchTimeout);
+                searchTimeout = setTimeout(() => {
+                    performSearch(e.target.value);
+                }, 300);
+            });
+            
+            // Update stats
+            document.getElementById('totalQuestions').textContent = faqData.length;
+        });
+    </script>
+</body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -1995,7 +1995,18 @@
                         <span style="color: var(--secondary);">→</span>
                     </div>
                 </div>
-                
+
+                <div class="settings-section">
+                    <h3 style="margin-bottom: 15px; color: var(--primary);">Help &amp; Support</h3>
+                    <a href="faq.html" target="_blank" class="settings-item">
+                        <div>
+                            <div style="font-weight: 600;">📖 FAQ</div>
+                            <div style="font-size: 0.85rem; color: var(--secondary); margin-top: 5px;">Common questions and answers</div>
+                        </div>
+                        <span style="color: var(--secondary);">→</span>
+                    </a>
+                </div>
+
                 <div class="settings-section">
                     <h3 style="margin-bottom: 15px; color: var(--primary);">About iKey</h3>
                     <div style="background: var(--light); padding: 20px; border-radius: 12px;">


### PR DESCRIPTION
## Summary
- add standalone FAQ page with searchable, categorized questions
- link to new FAQ page from a Help & Support section in Settings

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ikey4/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68c39b816ca4833281dc5f097bf86b60