### PR TITLE
feat: record share history in localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -2664,13 +2664,16 @@
                 const file = new File([blob], 'ikey-qr.png', { type: 'image/png' });
                 const shareData = { files: [file], title: 'iKey QR Code', text: 'Scan to view my emergency info' };
                 if (navigator.share && navigator.canShare && navigator.canShare({ files: [file] })) {
-                    navigator.share(shareData).catch(err => console.error('Share failed:', err));
+                    navigator.share(shareData)
+                        .then(() => logShare('qr_code', null, 'share'))
+                        .catch(err => console.error('Share failed:', err));
                 } else {
                     const link = document.createElement('a');
                     link.download = 'ikey-qr.png';
                     link.href = URL.createObjectURL(blob);
                     link.click();
                     URL.revokeObjectURL(link.href);
+                    logShare('qr_code', null, 'download');
                 }
             });
         }
@@ -2789,7 +2792,7 @@
             link.href = URL.createObjectURL(blob);
             link.download = 'emergency-card.html';
             link.click();
-            recordShare({type:'emergency_card', method:'download', date:new Date()});
+            logShare('emergency_card', null, 'download');
         }
 
         function downloadVCard() {
@@ -2799,7 +2802,7 @@
             link.href = URL.createObjectURL(blob);
             link.download = 'contact.vcf';
             link.click();
-            recordShare({type:'contact_card', method:'download', date:new Date()});
+            logShare('contact_card', null, 'download');
         }
 
         function smartCopy() {
@@ -2846,9 +2849,9 @@
             return { qrImage, textSummary, vCard, html };
         }
 
-        function recordShare(entry) {
+        function logShare(type, recipient, method) {
             const history = JSON.parse(localStorage.getItem('shareHistory') || '[]');
-            history.push(entry);
+            history.push({ type, recipient, method, date: new Date() });
             localStorage.setItem('shareHistory', JSON.stringify(history));
             showLastShare();
         }
@@ -2860,12 +2863,13 @@
             const container = document.getElementById('share-history');
             if (container) {
                 const date = new Date(last.date).toLocaleDateString();
-                container.textContent = `Last shared: ${last.type.replace('_',' ')} via ${last.method} (${date})`;
+                const recipient = last.recipient ? ` to ${last.recipient}` : '';
+                container.textContent = `Last shared: ${last.type.replace('_',' ')}${recipient} via ${last.method} (${date})`;
             }
         }
 
         function shareOptimized(type) {
-            recordShare({type: type, method:'share', date:new Date()});
+            logShare(type, null, 'share');
             if (navigator.share) {
                 navigator.share({text: 'iKey info'}).catch(()=>{});
             } else if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
@@ -3569,22 +3573,25 @@ Generated: ${new Date().toLocaleString()}`;
 
         async function shareLocation() {
             if (!currentLocation) return;
-            
+
             const shareData = {
                 title: 'My Location',
                 text: `Location: ${currentLocation.address}\nGPS: ${currentLocation.latitude}, ${currentLocation.longitude}`,
                 url: `https://maps.google.com/?q=${currentLocation.latitude},${currentLocation.longitude}`
             };
-            
+
             try {
                 if (navigator.share) {
                     await navigator.share(shareData);
+                    logShare('location', null, 'share');
                 } else {
                     copyAll();
+                    logShare('location', null, 'copy');
                 }
             } catch (err) {
                 console.error('Share failed:', err);
                 copyAll();
+                logShare('location', null, 'copy');
             }
         }
 


### PR DESCRIPTION
## Summary
- track shared content in `shareHistory` using a new `logShare` function
- display last share including share type, recipient and method
- record QR code, download, and location sharing events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3a5a3a72c833296ee0377236a40cf