### PR TITLE
feat: add smart clipboard copy options

### DIFF
--- a/index.html
+++ b/index.html
@@ -2803,11 +2803,11 @@
         }
 
         function smartCopy() {
-            const context = detectUserIntent();
-            if (context === 'medical_professional') {
+            const intent = detectUserIntent();
+            if (intent === 'medical_professional') {
                 copyMedicalSummary();
                 showToast('Medical summary copied - ready to paste into EMR');
-            } else if (context === 'text_message') {
+            } else if (intent === 'text_message') {
                 copyEmergencyBrief();
                 showToast('Emergency info copied for texting');
             } else {
@@ -2831,7 +2831,14 @@
         }
 
         function showCopyOptions() {
-            alert('Copy options not available in this context.');
+            const choice = prompt('Copy options:\n1. Full medical summary\n2. Emergency brief');
+            if (choice === '1') {
+                copyMedicalSummary();
+                showToast('Medical summary copied - ready to paste into EMR');
+            } else if (choice === '2') {
+                copyEmergencyBrief();
+                showToast('Emergency info copied for texting');
+            }
         }
 
         function showToast(msg) {


### PR DESCRIPTION
## Summary
- Detect user intent when copying and handle medical professional vs text message cases
- Provide fallback prompt to choose medical summary or emergency brief when intent unclear

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3a589f46c8332a311911bf210e7df