### PR TITLE
Rename Apps tab to Proton Apps in settings

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -271,7 +271,7 @@
             "poisonControlNumber": "Poison Control: 1-800-222-1222"
         },
         "misc": {
-            "apps": "Apps",
+            "apps": "Proton Apps",
             "proton": "Proton",
             "reading": "reading",
             "whats": "whats",
@@ -550,7 +550,7 @@
             "poisonControlNumber": "Control de Venenos: 1-800-222-1222"
         },
         "misc": {
-            "apps": "Apps",
+            "apps": "Proton Apps",
             "proton": "Proton",
             "reading": "lectura",
             "whats": "qué",
@@ -829,7 +829,7 @@
             "poisonControlNumber": "مراقبة السموم: 1-800-222-1222"
         },
         "misc": {
-            "apps": "التطبيقات",
+            "apps": "Proton Apps",
             "proton": "Proton",
             "reading": "قراءة",
             "whats": "ماذا",
@@ -1108,7 +1108,7 @@
             "poisonControlNumber": "Kontrola Jehrê: 1-800-222-1222"
         },
         "misc": {
-            "apps": "Sepan",
+            "apps": "Proton Apps",
             "proton": "Proton",
             "reading": "xwendin",
             "whats": "çi",
@@ -1387,7 +1387,7 @@
             "poisonControlNumber": "Xakamaynta Sunta: 1-800-222-1222"
         },
         "misc": {
-            "apps": "Apps",
+            "apps": "Proton Apps",
             "proton": "Proton",
             "reading": "akhrinta",
             "whats": "maxay",
@@ -1666,7 +1666,7 @@
             "poisonControlNumber": "中毒控制：1-800-222-1222"
         },
         "misc": {
-            "apps": "应用",
+            "apps": "Proton Apps",
             "proton": "Proton",
             "reading": "阅读",
             "whats": "什么",

--- a/index.html
+++ b/index.html
@@ -698,7 +698,7 @@
             border: none;
         }
 
-        /* Apps Tab */
+        /* Proton Apps Tab */
         .apps-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -1374,7 +1374,7 @@
             <span class="tab-icon">📡</span>
             <span class="tab-label" data-i18n="nav.dispatch">Dispatch</span>
         </button>
-        <button class="tab-btn proton-btn" onclick="switchTab('apps')" aria-label="Apps">
+        <button class="tab-btn proton-btn" onclick="switchTab('apps')" aria-label="Proton Apps">
             <img src="https://appfairness.org/wp-content/uploads/2021/09/logos-proton.jpg"
                  alt="Proton" class="proton-icon">
         </button>
@@ -1937,7 +1937,7 @@
         </div>
     </div>
 
-    <!-- Apps Tab -->
+    <!-- Proton Apps Tab -->
     <div id="apps" class="tab-content">
         <div class="container">
             <div class="apps-grid">
@@ -2076,7 +2076,7 @@
                     </div>
                     <div class="settings-item" style="cursor: default;">
                         <div>
-                            <div style="font-weight: 600;">📱 Apps</div>
+                            <div style="font-weight: 600;">📱 Proton Apps</div>
                         </div>
                         <input type="checkbox" class="tab-visibility-toggle" data-tab="apps" checked>
                     </div>
@@ -3296,7 +3296,7 @@ END:VCALENDAR`;
                     { id: 'wttin', name: 'Resources', icon: '🏠' },
                     { id: 'dispatch', name: 'Dispatch', icon: '📡' },
                     { id: 'meals', name: 'Meals', icon: '🍽️' },
-                    { id: 'apps', name: 'Apps', icon: '📱' },
+                    { id: 'apps', name: 'Proton Apps', icon: '📱' },
                     { id: 'settings', name: 'Settings', icon: '⚙️' }
                 ];
 
@@ -3402,7 +3402,7 @@ END:VCALENDAR`;
                     wttin: { name: 'Resources', icon: '🏠' },
                     dispatch: { name: 'Dispatch', icon: '📡' },
                     meals: { name: 'Meals', icon: '🍽️' },
-                    apps: { name: 'Apps', icon: '📱' },
+                    apps: { name: 'Proton Apps', icon: '📱' },
                     settings: { name: 'Settings', icon: '⚙️' }
                 };
 


### PR DESCRIPTION
## Summary
- Rename Apps navigation tab and settings toggle to **Proton Apps** for clearer branding.
- Update internal page labels and translation terms to use "Proton Apps" consistently.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3a7ffe5b483328669cca958159faf