### PR TITLE
style: smaller card logo and new front color

### DIFF
--- a/card.html
+++ b/card.html
@@ -315,7 +315,7 @@
 
         .card-front {
             padding: 15px;
-            background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+            background: #f8f3e8;
             height: 100%;
             display: flex;
             flex-direction: column;
@@ -337,8 +337,8 @@
         }
 
         .card-logo {
-            width: 32px;
-            height: 32px;
+            width: 24px;
+            height: 24px;
             background: linear-gradient(135deg, #667eea, #764ba2);
             border-radius: 8px;
             display: flex;
@@ -346,12 +346,12 @@
             justify-content: center;
             color: white;
             font-weight: bold;
-            font-size: 16px;
+            font-size: 12px;
         }
 
         .card-title {
             font-weight: 800;
-            font-size: 1.2rem;
+            font-size: 1rem;
             color: #333;
         }
 


### PR DESCRIPTION
## Summary
- reduce card logo and title sizes for a smaller iKey logo display
- set front card background to brand-friendly #f8f3e8

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3ad3efe24833288acc3eace19af07