### PR TITLE
Prevent warping of QR code and photo on physical cards

### DIFF
--- a/card.html
+++ b/card.html
@@ -381,6 +381,7 @@
             object-fit: cover;
             border: 2px solid #ddd;
             background: white;
+            aspect-ratio: 1 / 1;
         }
 
         .photo-placeholder-card {
@@ -404,12 +405,13 @@
             background: white;
             border-radius: 8px;
             border: 2px solid #ddd;
+            aspect-ratio: 1 / 1;
         }
 
         #qrcode canvas,
         #qrcode img {
             width: 100% !important;
-            height: 100% !important;
+            height: auto !important;
         }
 
         .email-display {


### PR DESCRIPTION
## Summary
- Maintain 1:1 aspect ratio for card photo and QR code containers
- Let QR code image scale without distortion by using auto height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3afa15e488332ab29d3527c2a7ca5