### PR TITLE
Fix card QR code base URL

### DIFF
--- a/card.html
+++ b/card.html
@@ -1123,7 +1123,8 @@
 
             const jsonStr = JSON.stringify(cleanData);
             const compressed = LZString.compressToEncodedURIComponent(jsonStr);
-            const baseURL = window.location.origin + window.location.pathname.replace('card.html', 'index.html');
+            const basePath = window.location.pathname.replace('card.html', '');
+            const baseURL = window.location.origin + basePath;
             const url = `${baseURL}#${compressed}`;
             const encodedUrl = encodeURI(url);
 


### PR DESCRIPTION
## Summary
- Ensure physical card QR code links include the base URL followed by hash-compressed data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3b0db1170833282e5022dc8f34dde