### PR TITLE
Lay out card backside in two columns

### DIFF
--- a/card.html
+++ b/card.html
@@ -447,12 +447,15 @@
             flex: 1;
             font-size: 0.72rem;
             overflow-y: auto;
+            column-count: 2;
+            column-gap: 12px;
         }
 
         .back-item {
             margin-bottom: 5px;
             display: flex;
             align-items: baseline;
+            break-inside: avoid;
         }
 
         .back-label {


### PR DESCRIPTION
## Summary
- Arrange medical info on the card's back in two columns so long text no longer overlaps with the emergency contact box.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c3b2ddcecc8332bb7aabdfc9db6419