### PR TITLE
Fix dark mode text color

### DIFF
--- a/invite.html
+++ b/invite.html
@@ -202,9 +202,14 @@
         }
 
         @media (prefers-color-scheme: dark) {
+            :root {
+                --text-dark: #f1f5f9;
+                --text-muted: #94a3b8;
+            }
+
             body {
                 background: #0f172a;
-                color: #f1f5f9;
+                color: var(--text-dark);
             }
 
             .widget-container {


### PR DESCRIPTION
## Summary
- ensure invitation generator uses light text in dark mode

## Testing
- `python -m py_compile scripts/generate_translation_doc.py`


------
https://chatgpt.com/codex/tasks/task_b_68c3b41ddbd88332a45f3bf2e6cae65f