### PR TITLE
Improve card photo and QR code quality

### DIFF
--- a/card.html
+++ b/card.html
@@ -392,18 +392,17 @@
         }
 
         .card-photo {
-            width: 90px;
-            height: 90px;
+            width: 100px;
+            aspect-ratio: 5 / 6;
             border-radius: 8px;
             object-fit: cover;
             border: 2px solid #ddd;
             background: white;
-            aspect-ratio: 1 / 1;
         }
 
         .photo-placeholder-card {
-            width: 90px;
-            height: 90px;
+            width: 100px;
+            aspect-ratio: 5 / 6;
             border-radius: 8px;
             border: 2px solid #ddd;
             background: #f8f9fa;
@@ -416,13 +415,12 @@
         }
 
         #qrcode {
-            width: 90px !important;
-            height: 90px !important;
+            width: 120px !important;
+            aspect-ratio: 1 / 1;
             padding: 7px;
             background: white;
             border-radius: 8px;
             border: 2px solid #ddd;
-            aspect-ratio: 1 / 1;
         }
 
         #qrcode canvas,
@@ -1173,8 +1171,8 @@
 
             qrCode = new QRCode(qrContainer, {
                 text: encodedUrl,
-                width: 76,
-                height: 76,
+                width: 240,
+                height: 240,
                 colorDark: "#000000",
                 colorLight: "#ffffff",
                 correctLevel: QRCode.CorrectLevel.L


### PR DESCRIPTION
## Summary
- Adjust ID card photo layout to use a 5:6 aspect ratio and larger dimensions for better clarity
- Increase QR code size and generation resolution for a crisper printout

## Testing
- `python -m py_compile scripts/generate_translation_doc.py`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_68c3b467bd648332be13a7a8465896ff