### PR TITLE
Remove dark mode styles and ensure accessible colors

### DIFF
--- a/card.html
+++ b/card.html
@@ -21,6 +21,7 @@
             background: #f8fafc;
             min-height: 100vh;
             padding: 20px;
+            color: #1e293b;
         }
 
         *:focus-visible {
@@ -558,17 +559,7 @@
             }
         }
 
-        @media (prefers-color-scheme: dark) {
-            body {
-                background: #0f172a;
-                color: #f1f5f9;
-            }
-
-            .controls,
-            .preview-container {
-                background: #1e293b;
-            }
-        }
+        /* Dark mode styles removed to maintain accessible contrast */
     </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -1442,25 +1442,7 @@
             }
         }
 
-        @media (prefers-color-scheme: dark) {
-            :root {
-                --primary: #818cf8;
-                --danger: #f87171;
-                --success: #4ade80;
-                --light: #1e293b;
-                --dark: #f1f5f9;
-                --border: #334155;
-            }
-
-            body {
-                background: #0f172a;
-                color: #f1f5f9;
-            }
-
-            .card {
-                background: #1e293b;
-            }
-        }
+        /* Dark mode styles removed to maintain accessible contrast */
 
         </style>
 </head>

--- a/invite.html
+++ b/invite.html
@@ -201,25 +201,7 @@
             }
         }
 
-        @media (prefers-color-scheme: dark) {
-            :root {
-                --text-dark: #f1f5f9;
-                --text-muted: #94a3b8;
-            }
-
-            body {
-                background: #0f172a;
-                color: var(--text-dark);
-            }
-
-            .widget-container {
-                background: #1e293b;
-            }
-
-            .widget-header {
-                background: #818cf8;
-            }
-        }
+        /* Dark mode styles removed to maintain accessible contrast */
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Remove dark-mode media queries from public pages
- Add explicit dark text color for card generator to maintain contrast

## Testing
- `python -m py_compile scripts/generate_translation_doc.py`
- `node --check scripts/translate.js`


------
https://chatgpt.com/codex/tasks/task_b_68c3b4d24e7c8332bcfe1aa3f00da8ac