### PR TITLE
Fix poison control quick action dialing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3453,7 +3453,7 @@ END:VCALENDAR`;
                     'call-911': { name: 'Emergency', url: 'tel:911', icon: '🚨' },
                     'text-911': { name: 'Text 911', url: 'sms:911', icon: '💬' },
                     'call-988': { name: 'Crisis Line', url: 'tel:988', icon: '💬' },
-                    'call-poison': { name: 'Poison Control', url: 'tel:18002221222', icon: '☠️' },
+                    'call-poison': { name: 'Poison Control', url: 'tel:+18002221222', icon: '☠️' },
                     'text-quick': { name: 'Quick Text', url: 'sms:', icon: '💬' }
                 };
 


### PR DESCRIPTION
## Summary
- ensure Poison Control quick action uses `tel:+18002221222` so the phone number launches correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c4f1bad054833289f5ce03f65005d1