### PR TITLE
Add helper for translating dynamic UI fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The project is a collection of static HTML files. Open `index.html` directly in 
 
 The repository has no build step. Edits can be made directly to the HTML or translation files. A helper script in `scripts/generate_translation_doc.py` regenerates the translation document when new terms are added.
 
+### Dynamic translations
+
+When adding DOM elements at runtime (wizards, modals, etc.), call the global `translateFragment(rootElement)` helper from `scripts/translate.js`. It applies `data-i18n*` translations to the supplied subtree so new UI fragments are translated immediately.
+
 ## License
 
 This project is provided as a public good. Use at your own discretion and always verify critical information before sharing it in emergencies.

--- a/index.html
+++ b/index.html
@@ -2613,6 +2613,7 @@
             `;
 
             document.getElementById('review-content').innerHTML = reviewHTML;
+            translateFragment(document.getElementById('review-content'));
         }
         function generateQR() {
             const cleanData = {};
@@ -3120,6 +3121,7 @@ END:VCALENDAR`;
                 html += '</div>';
 
                 container.innerHTML = html;
+                translateFragment(container);
                 this.attachHandlers();
             }
 
@@ -3275,6 +3277,7 @@ END:VCALENDAR`;
 
                 const modal = this.createModal();
                 document.body.appendChild(modal);
+                translateFragment(modal);
 
                 this.updateCustomForm();
             }
@@ -3434,6 +3437,7 @@ END:VCALENDAR`;
                 }
 
                 fieldsDiv.innerHTML = html;
+                translateFragment(fieldsDiv);
             }
 
             addProtonApp(appId) {

--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -26,21 +26,25 @@ function t(key, fallback = '') {
   return text || fallback;
 }
 
+function translateFragment(root = document) {
+  root.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = t(el.dataset.i18n, el.textContent);
+  });
+  root.querySelectorAll('[data-i18n-aria]').forEach(el => {
+    el.setAttribute('aria-label', t(el.dataset.i18nAria, el.getAttribute('aria-label') || ''));
+  });
+  root.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.setAttribute('placeholder', t(el.dataset.i18nPlaceholder, el.getAttribute('placeholder') || ''));
+  });
+}
+
 function setLanguage(lang) {
   document.documentElement.lang = lang;
   localStorage.setItem('language', lang);
   document.querySelectorAll('.lang-option').forEach(btn => {
     btn.classList.toggle('active', btn.dataset.lang === lang);
   });
-  document.querySelectorAll('[data-i18n]').forEach(el => {
-    el.textContent = t(el.dataset.i18n, el.textContent);
-  });
-  document.querySelectorAll('[data-i18n-aria]').forEach(el => {
-    el.setAttribute('aria-label', t(el.dataset.i18nAria, el.getAttribute('aria-label') || ''));
-  });
-  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
-    el.setAttribute('placeholder', t(el.dataset.i18nPlaceholder, el.getAttribute('placeholder') || ''));
-  });
+  translateFragment(document);
 }
 
 const languageBtn = document.getElementById('language-btn');
@@ -56,5 +60,7 @@ if (languageBtn && languageMenu) {
     });
   });
 }
+
+window.translateFragment = translateFragment;
 
 document.addEventListener('DOMContentLoaded', loadTranslations);


### PR DESCRIPTION
## Summary
- expose `translateFragment` helper to translate DOM subtrees on demand
- invoke translation helper when creating bookmark wizards and review panels
- document how to apply translations to dynamically added elements

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c4f28a025483328e351c49e8f4015c