### PR TITLE
fix: allow natural click after touch

### DIFF
--- a/index.html
+++ b/index.html
@@ -3438,11 +3438,10 @@ END:VCALENDAR`;
 
             handleTouchEnd(e) {
                 const touchDuration = Date.now() - this.touchStartTime;
+                this.cancelLongPress();
                 if (touchDuration < 200 && !this.editMode) {
-                    this.cancelLongPress();
-                    this.handleClick(e);
-                } else {
-                    this.cancelLongPress();
+                    // Let the natural click event handle navigation
+                    return;
                 }
             }
 


### PR DESCRIPTION
## Summary
- stop manually triggering click on touch end so taps fire native click events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c4f5c6195c8332a5f75c882805b1e9