### PR TITLE
Handle devices that can't share QR image

### DIFF
--- a/index.html
+++ b/index.html
@@ -3243,20 +3243,29 @@
                 return;
             }
 
+            const shareUrl = window.location.href;
+
             canvas.toBlob(async function(blob) {
                 const file = new File([blob], 'ikey-qr.png', { type: 'image/png' });
-                const shareData = {
+                let shareData = {
                     files: [file],
                     title: 'iKey QR Code',
                     text: 'Scan to view my emergency info',
-                    url: window.location.href
+                    url: shareUrl
                 };
+
                 try {
-                    if (!navigator.canShare || navigator.canShare({ files: [file] })) {
-                        await navigator.share(shareData);
-                        logShare('qr_code', null, 'share');
-                        return;
+                    if (navigator.canShare && !navigator.canShare({ files: [file] })) {
+                        // Some browsers support sharing but not with files
+                        shareData = {
+                            title: 'iKey QR Code',
+                            text: 'Scan to view my emergency info',
+                            url: shareUrl
+                        };
                     }
+                    await navigator.share(shareData);
+                    logShare('qr_code', null, 'share');
+                    return;
                 } catch (err) {
                     console.error('Share failed:', err);
                     showToast('⚠️ Share failed. Downloading QR instead.');


### PR DESCRIPTION
## Summary
- Attempt QR sharing even when `navigator.canShare` disallows file sharing
- Fallback to sharing link or downloading QR image when file sharing is unsupported or fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c58eef95c08332876f507dfdcd771f