### PR TITLE
Display email in card header and reduce GUID size

### DIFF
--- a/card.html
+++ b/card.html
@@ -375,10 +375,23 @@
             color: #333;
         }
 
-        .card-id {
-            font-size: 0.7rem;
-            color: #666;
+        .id-container {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            text-align: right;
+        }
+
+        .card-email {
+            font-size: 0.85rem;
+            color: #333;
             font-weight: 600;
+        }
+
+        .card-id {
+            font-size: 0.55rem;
+            color: #666;
+            font-weight: 500;
         }
 
         .id-section {
@@ -429,18 +442,6 @@
         #qrcode img {
             width: 100% !important;
             height: auto !important;
-        }
-
-        .email-display {
-            background: linear-gradient(135deg, #667eea, #764ba2);
-            color: white;
-            padding: 10px 20px;
-            border-radius: 8px;
-            font-weight: 600;
-            font-size: 0.9rem;
-            text-align: center;
-            width: 100%;
-            max-width: 280px;
         }
 
         .card-back {
@@ -769,7 +770,10 @@
                                     <div class="card-logo">iK</div>
                                     <div class="card-title" data-i18n="card.cardName">iKey</div>
                                 </div>
-                                <div class="card-id" id="display_cardId">00000000-0000-0000-0000-000000000000</div>
+                                <div class="id-container">
+                                    <div class="card-email" id="display_email">you@proton.me</div>
+                                    <div class="card-id" id="display_cardId">00000000-0000-0000-0000-000000000000</div>
+                                </div>
                             </div>
 
                             <div class="id-section" id="idSection">
@@ -782,7 +786,6 @@
                                 <div id="qrcode"></div>
                             </div>
 
-                            <div class="email-display" id="display_email"></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Show the user's ProtonMail address in the card header where the GUID used to be
- Place the GUID below the email with a smaller font
- Clean up unused email-display styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c58fd1a9b48332ba898229d0dc3b98