### PR TITLE
Show emergency modal only on first QR scan

### DIFF
--- a/index.html
+++ b/index.html
@@ -5326,8 +5326,13 @@ Generated: ${new Date().toLocaleString()}`;
 
                     displayData = data;
 
-                    // Show emergency modal instead of switching to display view
-                    showEmergencyModal(data);
+                    const scanKey = `scanned_${hash}`;
+                    if (!localStorage.getItem(scanKey)) {
+                        localStorage.setItem(scanKey, '1');
+                        showEmergencyModal(data);
+                    } else {
+                        initializeDisplayView(data);
+                    }
 
                     // Switch to home tab (modal will be on top)
                     switchTab('home');


### PR DESCRIPTION
## Summary
- Display emergency info modal only on the first scan of a specific QR code per device.
- Initialize display view on subsequent scans without showing the modal.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c59049ea08833298568f8f23f48852