### PR TITLE
feat: add floating share panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1564,6 +1564,195 @@
             font-size: 0.875rem;
         }
 
+        /* Display container with grid layout */
+        .display-container {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 20px;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            position: relative;
+        }
+
+        .display-main {
+            min-width: 0;
+        }
+
+        /* Floating Share Panel */
+        .floating-share-panel {
+            position: sticky;
+            top: 80px;
+            height: fit-content;
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+            padding: 12px;
+            min-width: 140px;
+            border: 1px solid rgba(0, 0, 0, 0.06);
+            transition: all 0.3s ease;
+        }
+
+        .floating-share-panel:hover {
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        }
+
+        /* Panel Header */
+        .share-panel-header {
+            padding: 8px 12px;
+            margin-bottom: 8px;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: #6b7280;
+            font-weight: 600;
+            text-align: center;
+        }
+
+        /* Share Buttons */
+        .floating-share-btn {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            width: 100%;
+            padding: 12px 16px;
+            margin-bottom: 4px;
+            background: #f8fafc;
+            border: none;
+            border-radius: 12px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            font-size: 14px;
+            font-weight: 500;
+            color: #1e293b;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .floating-share-btn::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 0;
+            height: 100%;
+            background: linear-gradient(90deg, #4f46e5, #7c3aed);
+            transition: width 0.3s ease;
+            opacity: 0.1;
+        }
+
+        .floating-share-btn:hover::before {
+            width: 100%;
+        }
+
+        .floating-share-btn:hover {
+            background: white;
+            transform: translateX(4px);
+            box-shadow: 0 2px 12px rgba(79, 70, 229, 0.15);
+        }
+
+        .floating-share-btn:active {
+            transform: translateX(2px) scale(0.98);
+        }
+
+        .share-icon {
+            font-size: 20px;
+            width: 24px;
+            text-align: center;
+        }
+
+        .share-label {
+            flex: 1;
+            text-align: left;
+        }
+
+        /* Emergency button styling */
+        .floating-share-btn.emergency {
+            background: #fee2e2;
+            margin-top: 8px;
+        }
+
+        .floating-share-btn.emergency:hover {
+            background: #fecaca;
+            box-shadow: 0 2px 12px rgba(239, 68, 68, 0.2);
+        }
+
+        .floating-share-btn.emergency::before {
+            background: linear-gradient(90deg, #ef4444, #dc2626);
+        }
+
+        /* Divider */
+        .share-panel-divider {
+            height: 1px;
+            background: #e2e8f0;
+            margin: 12px 0;
+        }
+
+        /* Mobile responsiveness */
+        @media (max-width: 768px) {
+            .display-container {
+                grid-template-columns: 1fr;
+            }
+
+            .floating-share-panel {
+                position: fixed;
+                bottom: 20px;
+                right: 20px;
+                top: auto;
+                width: 60px;
+                padding: 8px;
+                z-index: 100;
+            }
+
+            .share-panel-header {
+                display: none;
+            }
+
+            .floating-share-btn {
+                padding: 12px;
+                justify-content: center;
+            }
+
+            .share-label {
+                display: none;
+            }
+
+            .floating-share-btn:hover {
+                transform: scale(1.1);
+            }
+        }
+
+        /* Collapsed state for desktop */
+        @media (min-width: 769px) {
+            .floating-share-panel.collapsed {
+                min-width: auto;
+            }
+
+            .floating-share-panel.collapsed .share-label,
+            .floating-share-panel.collapsed .share-panel-header {
+                display: none;
+            }
+
+            .floating-share-panel.collapsed .floating-share-btn {
+                padding: 12px;
+                justify-content: center;
+            }
+        }
+
+        /* Add collapse toggle button */
+        .panel-toggle {
+            position: absolute;
+            top: 8px;
+            right: 8px;
+            width: 20px;
+            height: 20px;
+            border: none;
+            background: none;
+            cursor: pointer;
+            color: #6b7280;
+            font-size: 12px;
+        }
+
         @media (prefers-contrast: high) {
             :root {
                 --primary: #3730a3;
@@ -2025,28 +2214,53 @@
 
                 <!-- Display View (for existing data) -->
                 <div id="display-view" class="hidden">
-                    <h2>Emergency Essential Info</h2>
-                    <div id="display-content"></div>
-                    <div id="communication-actions" style="margin-top: 20px;"></div>
-                    <div class="share-actions">
-                        <button onclick="shareQR()">
-                            📤 Share
-                            <span class="subtitle">Use device share options</span>
-                        </button>
-                        <button onclick="smsInfo()">
-                            💬 Text
-                            <span class="subtitle">Send link via SMS</span>
-                        </button>
-                        <button onclick="emailInfo()">
-                            ✉️ Email
-                            <span class="subtitle">Send link via email</span>
-                        </button>
-                        <button onclick="saveQRImage()">
-                            💾 Save Image
-                            <span class="subtitle">Download QR code</span>
-                        </button>
+                    <div class="display-container">
+                        <div class="display-main">
+                            <h2>Emergency Essential Info</h2>
+                            <div id="display-content"></div>
+                            <div id="communication-actions" style="margin-top: 20px;"></div>
+                            <div id="share-history" style="margin-top:10px; font-size:0.9rem; color: var(--secondary);"></div>
+                        </div>
+
+                        <!-- Floating Share Panel -->
+                        <div class="floating-share-panel">
+                            <div class="share-panel-header">
+                                <span>Quick Actions</span>
+                            </div>
+
+                            <button class="floating-share-btn" onclick="shareQR()" aria-label="Share">
+                                <span class="share-icon">📤</span>
+                                <span class="share-label">Share</span>
+                            </button>
+
+                            <button class="floating-share-btn" onclick="smsInfo()" aria-label="Text">
+                                <span class="share-icon">💬</span>
+                                <span class="share-label">Text</span>
+                            </button>
+
+                            <button class="floating-share-btn" onclick="emailInfo()" aria-label="Email">
+                                <span class="share-icon">✉️</span>
+                                <span class="share-label">Email</span>
+                            </button>
+
+                            <button class="floating-share-btn" onclick="copyLinkForEmail()" aria-label="Copy">
+                                <span class="share-icon">📋</span>
+                                <span class="share-label">Copy</span>
+                            </button>
+
+                            <button class="floating-share-btn" onclick="saveQRImage()" aria-label="Save QR">
+                                <span class="share-icon">💾</span>
+                                <span class="share-label">Save QR</span>
+                            </button>
+
+                            <div class="share-panel-divider"></div>
+
+                            <button class="floating-share-btn emergency" onclick="window.location.href='tel:911'" aria-label="Call 911">
+                                <span class="share-icon">🚨</span>
+                                <span class="share-label">Call 911</span>
+                            </button>
+                        </div>
                     </div>
-                    <div id="share-history" style="margin-top:10px; font-size:0.9rem; color: var(--secondary);"></div>
                 </div>
 
                 <!-- QR Code View -->
@@ -3208,6 +3422,13 @@
             });
         }
 
+        function copyLinkForEmail() {
+            navigator.clipboard.writeText(window.location.href).then(() => {
+                showToast('Link copied to clipboard!');
+                logShare('qr_code', null, 'copy');
+            });
+        }
+
         function getMedicalInfoText(dataObj = formData) {
             const data = dataObj || {};
             const lines = [];
@@ -3445,6 +3666,24 @@
                 const recipient = last.recipient ? ` to ${last.recipient}` : '';
                 container.textContent = `Last shared: ${last.type.replace('_',' ')}${recipient} via ${last.method} (${date})`;
             }
+        }
+
+        function initFloatingPanel() {
+            const panel = document.querySelector('.floating-share-panel');
+            if (!panel) return;
+            let lastScroll = 0;
+            window.addEventListener('scroll', () => {
+                const currentScroll = window.pageYOffset;
+                if (currentScroll > lastScroll && currentScroll > 100) {
+                    panel.style.opacity = '0.7';
+                } else {
+                    panel.style.opacity = '1';
+                }
+                lastScroll = currentScroll;
+            });
+            panel.addEventListener('mouseenter', () => {
+                panel.style.opacity = '1';
+            });
         }
 
         function createNew() {
@@ -5312,6 +5551,7 @@ Generated: ${new Date().toLocaleString()}`;
                 inviteAppLink.href = `invite.html?key=${encodeURIComponent(storagePrefix)}`;
             }
             showLastShare();
+            initFloatingPanel();
 
             // Check for existing QR data in URL
             const hash = decodeURIComponent(window.location.hash.slice(1));


### PR DESCRIPTION
## Summary
- redesign display view with sticky floating share panel for quick sharing actions
- style floating panel with responsive layout and emergency 911 button
- add behavior to fade panel on scroll and copy link helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c59009f3d08332a7b0b32ff8081141