### PR TITLE
Add location sharing prompt at top of 911 tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -2311,6 +2311,11 @@
 <!-- Emergency Services Tab -->
 <div id="emergency" class="tab-content">
         <div class="container">
+            <div class="location-share-tip" style="margin-bottom: 20px;">
+                <button class="btn btn-secondary" onclick="getLocation()">Enable Location Sharing</button>
+                <p style="font-size: 0.85rem; color: var(--secondary); margin-top: 5px;">Helps get your precise location to give operators.</p>
+            </div>
+
             <a href="tel:911" class="emergency-button">
                 <span class="icon">📞</span>
                 <span>Call 911</span>
@@ -2329,7 +2334,6 @@
                     <div class="loading-spinner"></div>
                     <p>Acquiring secure location...</p>
                     <p style="font-size: 0.85rem; color: var(--secondary); margin-top: 5px;">Please allow location access</p>
-                    <button class="btn btn-secondary" onclick="getLocation()" style="margin-top: 10px;" data-i18n="emergency.enableLocation">Enable Location</button>
                 </div>
                 
                 <div id="emergency-content" style="display: none;">


### PR DESCRIPTION
## Summary
- Show an **Enable Location Sharing** button at the top of the 911 tab
- Remove duplicate enable button from location loading section
- Inform users that sharing location helps provide precise details to operators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5932fc4b88332ad13de2b04f8ee86