### PR TITLE
Wrap nav items and scale for larger text

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,25 +140,23 @@
             background: white;
             border-bottom: 1px solid #e5e7eb;
             display: flex;
-            height: 44px;
+            flex-wrap: wrap;
+            justify-content: center;
+            height: auto;
             padding: 0;
             position: sticky;
             top: 0;
             z-index: 100;
-            overflow-x: auto;
-            overflow-y: hidden;
-            scroll-behavior: smooth;
-            -webkit-overflow-scrolling: touch;
         }
 
         .tab-btn {
             flex: 0 0 auto;
-            min-width: 64px;
-            padding: 4px 8px;
+            min-width: 4rem;
+            padding: 0.5rem 0.75rem;
             background: none;
             border: none;
             color: #64748b;
-            font-size: 11px;
+            font-size: 1rem;
             font-weight: 600;
             cursor: pointer;
             transition: all 0.2s;
@@ -166,10 +164,10 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            gap: 2px;
+            gap: 4px;
             border-bottom: 3px solid transparent;
-            white-space: nowrap;
             position: relative;
+            text-align: center;
         }
 
         .tab-btn:active {
@@ -186,13 +184,13 @@
         }
 
         .tab-icon {
-            font-size: 18px;
+            font-size: 1.5rem;
             line-height: 1;
-            height: 18px;
+            height: 1.5rem;
         }
 
         .tab-label {
-            font-size: 10px;
+            font-size: 0.9rem;
             line-height: 1;
             opacity: 0.9;
             margin-top: 2px;
@@ -200,11 +198,11 @@
 
         /* Hide Proton image in compact mode */
         .tab-btn.proton-btn {
-            padding: 4px 12px;
+            padding: 0.25rem 0.75rem;
         }
 
         .tab-btn.proton-btn .proton-icon {
-            height: 20px;
+            height: 1.25rem;
             width: auto;
         }
 
@@ -235,27 +233,32 @@
         }
 
         @media (max-width: 480px) {
-            .tab-label {
-                display: none;
-            }
-
             .tab-btn {
-                padding: 8px;
-                min-width: 48px;
+                padding: 0.5rem;
+                min-width: 3rem;
             }
 
             .tab-icon {
-                font-size: 20px;
+                font-size: 1.25rem;
+            }
+
+            .tab-label {
+                font-size: 0.8rem;
             }
         }
 
         @media (min-width: 768px) {
-            .tab-nav {
-                display: grid;
-                grid-template-columns: repeat(5, 1fr);
-                grid-template-rows: repeat(2, 24px);
-                height: 48px;
-                gap: 0;
+            .tab-btn {
+                font-size: 1.1rem;
+            }
+
+            .tab-icon {
+                font-size: 1.75rem;
+                height: 1.75rem;
+            }
+
+            .tab-label {
+                font-size: 1rem;
             }
         }
 


### PR DESCRIPTION
## Summary
- Allow navigation bar items to wrap to new rows and center them
- Use relative units so nav icons and labels scale with text size
- Increase nav sizes on both small and large displays

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5949799048332ab71115cb9860d11