### PR TITLE
feat: add collapsible share bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -575,29 +575,6 @@
             margin-bottom: 15px;
         }
 
-        .share-actions {
-            display: flex;
-            flex-direction: column;
-            gap: 10px;
-            margin-top: 20px;
-        }
-
-        .share-actions button {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            padding: 10px;
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            background: var(--light);
-            cursor: pointer;
-        }
-
-        .share-actions .subtitle {
-            font-size: 0.8rem;
-            color: var(--secondary);
-        }
-
         .qr-display-card {
             border: 1px solid var(--border);
             border-radius: 8px;
@@ -1610,14 +1587,14 @@
             min-width: 0;
         }
 
-        /* Share Bar */
+        /* Collapsible Share Bar */
         .share-bar {
             margin: 20px 0;
             background: #f8fafc;
             border-radius: 12px;
             border: 1px solid #e5e7eb;
             overflow: hidden;
-            transition: all 0.3s;
+            transition: all 0.3s ease;
         }
 
         .share-toggle {
@@ -1631,15 +1608,32 @@
             cursor: pointer;
             font-weight: 600;
             color: #4f46e5;
+            font-size: 14px;
+        }
+
+        .share-toggle:hover {
+            background: rgba(79, 70, 229, 0.05);
         }
 
         .toggle-icon {
             transition: transform 0.3s;
             display: inline-block;
+            font-size: 12px;
+        }
+
+        .toggle-hint {
+            margin-left: auto;
+            font-size: 12px;
+            font-weight: normal;
+            color: #94a3b8;
         }
 
         .share-bar:not(.collapsed) .toggle-icon {
             transform: rotate(90deg);
+        }
+
+        .share-bar:not(.collapsed) .toggle-hint {
+            display: none;
         }
 
         .share-options {
@@ -1647,10 +1641,16 @@
             gap: 8px;
             padding: 0 16px 12px;
             flex-wrap: wrap;
+            opacity: 1;
+            max-height: 200px;
+            transition: all 0.3s ease;
         }
 
         .share-bar.collapsed .share-options {
-            display: none;
+            opacity: 0;
+            max-height: 0;
+            padding: 0 16px;
+            overflow: hidden;
         }
 
         .share-options button {
@@ -1661,12 +1661,31 @@
             cursor: pointer;
             font-size: 14px;
             transition: all 0.2s;
+            flex: 0 0 auto;
         }
 
         .share-options button:hover {
             background: #4f46e5;
             color: white;
             border-color: #4f46e5;
+            transform: translateY(-2px);
+            box-shadow: 0 2px 8px rgba(79, 70, 229, 0.3);
+        }
+
+        .share-options button:active {
+            transform: translateY(0);
+        }
+
+        /* Mobile responsive */
+        @media (max-width: 480px) {
+            .share-options {
+                flex-direction: column;
+            }
+            
+            .share-options button {
+                width: 100%;
+                text-align: left;
+            }
         }
 
         @media (prefers-contrast: high) {
@@ -2130,10 +2149,14 @@
                         <div class="display-main">
                             <h2>Emergency Essential Info</h2>
                             <div id="display-content"></div>
+                            <div id="communication-actions" style="margin-top: 20px;"></div>
+
+                            <!-- Collapsible Share Bar -->
                             <div class="share-bar collapsed">
                                 <button class="share-toggle" onclick="toggleShareBar()">
                                     <span class="toggle-icon">▶</span>
                                     <span class="toggle-text">Share Options</span>
+                                    <span class="toggle-hint">(Click to expand)</span>
                                 </button>
 
                                 <div class="share-options">
@@ -2144,7 +2167,6 @@
                                     <button onclick="saveQRImage()">💾 Save</button>
                                 </div>
                             </div>
-                            <div id="communication-actions" style="margin-top: 20px;"></div>
                             <div id="share-history" style="margin-top:10px; font-size:0.9rem; color: var(--secondary);"></div>
                         </div>
                     </div>
@@ -3625,16 +3647,21 @@
 
         function toggleShareBar() {
             const bar = document.querySelector('.share-bar');
+            if (!bar) return;
+
             bar.classList.toggle('collapsed');
+
+            // Update hint text
+            const hint = bar.querySelector('.toggle-hint');
+            if (hint) {
+                hint.textContent = bar.classList.contains('collapsed') 
+                    ? '(Click to expand)' 
+                    : '(Click to collapse)';
+            }
+
+            // Save preference
             localStorage.setItem('shareBarCollapsed', bar.classList.contains('collapsed'));
         }
-
-        document.addEventListener('DOMContentLoaded', () => {
-            const collapsed = localStorage.getItem('shareBarCollapsed');
-            if (collapsed === 'false') {
-                document.querySelector('.share-bar')?.classList.remove('collapsed');
-            }
-        });
 
         function createNew() {
             if (confirm('Create a new iKey? This will take you to the base URL.')) {
@@ -4870,6 +4897,7 @@ Generated: ${new Date().toLocaleString()}`;
             // This sets up the regular display view that users can access via tabs
             document.getElementById('wizard-view').classList.add('hidden');
             document.getElementById('display-view').classList.remove('hidden');
+            document.querySelector('.share-bar')?.style.display = 'block';
 
             // Generate communication cards
             let commCards = '';
@@ -5459,6 +5487,17 @@ Generated: ${new Date().toLocaleString()}`;
         document.addEventListener('DOMContentLoaded', function() {
             setupCharacterCounters();
             setupDocumentDropdowns();
+
+            // Restore share bar state
+            const shareBarState = localStorage.getItem('shareBarCollapsed');
+            if (shareBarState === 'false') {
+                const bar = document.querySelector('.share-bar');
+                if (bar) {
+                    bar.classList.remove('collapsed');
+                    const hint = bar.querySelector('.toggle-hint');
+                    if (hint) hint.textContent = '(Click to collapse)';
+                }
+            }
 
             // Haptics toggle
             const hapticsToggle = document.getElementById('haptics-toggle');


### PR DESCRIPTION
## Summary
- implement inline collapsible share bar after communication actions
- add responsive styling and state persistence for share options
- initialize display view to show share bar and restore user preference

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c59595f7c48332af7d6f5560d2e46d