### PR TITLE
Handle haptics localStorage errors and allow tab switching without vibration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2785,7 +2785,13 @@
             },
             trigger: function(pattern = 'light') {
                 if (!this.isSupported()) return;
-                const hapticsEnabled = localStorage.getItem('hapticsEnabled') !== 'false';
+                let hapticsEnabled = false;
+                try {
+                    hapticsEnabled = localStorage.getItem('hapticsEnabled') !== 'false';
+                } catch (e) {
+                    console.error('Error accessing localStorage for haptics:', e);
+                    hapticsEnabled = false;
+                }
                 if (!hapticsEnabled) return;
                 const vibrationPattern = this.patterns[pattern] || pattern;
                 try {
@@ -2824,7 +2830,9 @@
 
         // Tab switching
         function switchTab(tabName) {
-            HapticFeedback.trigger('light');
+            if (typeof HapticFeedback !== 'undefined' && typeof HapticFeedback.trigger === 'function') {
+                HapticFeedback.trigger('light');
+            }
             // Hide dropdown when switching tabs
             const menu = document.getElementById('resource-menu');
             if (menu) {


### PR DESCRIPTION
## Summary
- Guard `localStorage.getItem('hapticsEnabled')` with a try/catch and default to disabled when access fails
- Skip triggering haptics in `switchTab` when the feature is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c598c440dc83329160ff4c195c5c05