### PR TITLE
Fix navigation break from optional chaining

### DIFF
--- a/index.html
+++ b/index.html
@@ -4848,7 +4848,8 @@ Generated: ${new Date().toLocaleString()}`;
             // This sets up the regular display view that users can access via tabs
             document.getElementById('wizard-view').classList.add('hidden');
             document.getElementById('display-view').classList.remove('hidden');
-            document.querySelector('.share-bar')?.style.display = 'block';
+            const bar = document.querySelector('.share-bar');
+            if (bar) bar.style.display = 'block';
 
             // Generate communication cards
             let commCards = '';


### PR DESCRIPTION
## Summary
- Replace invalid optional chaining assignment in `initializeDisplayView` with a null check
- Prevent script parse error that stopped navigation and click handlers

## Testing
- `node --check all-scripts.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_b_68c59b186f488332b40ca52b9d1bf275