### PR TITLE
Fix tab navigation by removing invalid optional chaining assignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -4848,7 +4848,10 @@ Generated: ${new Date().toLocaleString()}`;
             // This sets up the regular display view that users can access via tabs
             document.getElementById('wizard-view').classList.add('hidden');
             document.getElementById('display-view').classList.remove('hidden');
-            document.querySelector('.share-bar')?.style.display = 'block';
+            const shareBar = document.querySelector('.share-bar');
+            if (shareBar) {
+                shareBar.style.display = 'block';
+            }
 
             // Generate communication cards
             let commCards = '';


### PR DESCRIPTION
## Summary
- Replace invalid optional chaining assignment with a conditional share bar display

## Testing
- `node jsdom-debug.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68c59b186f488332b40ca52b9d1bf275