### PR TITLE
Fix share action when QR code not pre-generated

### DIFF
--- a/index.html
+++ b/index.html
@@ -3433,11 +3433,10 @@
         }
 
         function shareQR(target = 'qrcode') {
-            const canvas = getQRCodeCanvas(target);
-            if (!canvas) {
-                alert('Please generate QR code first');
-                return;
-            }
+            // Allow sharing even if a QR code hasn't been generated yet.
+            // The previous implementation required an existing QR canvas and
+            // alerted users when it was missing. However, the share action only
+            // needs the current URL, so we can proceed regardless of QR state.
 
             const shareUrl = window.location.href;
             const shareText = `My iKey Emergency Info: ${shareUrl}`;


### PR DESCRIPTION
## Summary
- Allow share function to proceed even when QR code canvas is missing
- Add comments explaining that sharing only requires current URL

## Testing
- `python -m py_compile scripts/generate_translation_doc.py`


------
https://chatgpt.com/codex/tasks/task_b_68c59d32898c8332bab88885eba142b2