### PR TITLE
Allow multiple Proton Mail domains

### DIFF
--- a/index.html
+++ b/index.html
@@ -3025,7 +3025,7 @@
         function validateStep(step) {
             if (step === 2) {
                 const email = document.getElementById('secure-email').value.trim();
-                const regex = /^[^\s@]+@(proton\.me|protonmail\.com)$/i;
+                const regex = /^[^\s@]+@(proton\.me|protonmail\.com|protonmail\.ch|pm\.me)$/i;
                 if (!regex.test(email)) {
                     alert('Please enter a valid Proton email address');
                     return false;


### PR DESCRIPTION
## Summary
- Expand Proton email validation to accept `pm.me` and `protonmail.ch` addresses in addition to existing domains

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c59e0744c483329b88ce8f3297c564