### PR TITLE
Rename Medical ID to iKey Emergency ID and fix status card

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -355,7 +355,7 @@
         "card": {
             "title": "iKey ID Card Generator",
             "header": "iKey ID Card Generator",
-            "tagline": "Minimalist secure medical ID with unique identifier",
+            "tagline": "Minimalist secure iKey Emergency ID with unique identifier",
             "photoUpload": "Photo Upload (Optional)",
             "noPhoto": "No Photo",
             "takePhoto": "📸 Take Photo",

--- a/card.html
+++ b/card.html
@@ -597,7 +597,7 @@
                 <div class="main-logo">iK</div>
                 <span data-i18n="card.header">iKey ID Card Generator</span>
             </h1>
-            <p data-i18n="card.tagline">Minimalist secure medical ID with unique identifier</p>
+            <p data-i18n="card.tagline">Minimalist secure iKey Emergency ID with unique identifier</p>
         </div>
 
         <div class="controls">
@@ -1331,7 +1331,7 @@
 
             const cardId = document.getElementById('display_cardId').textContent;
 
-            const content = `iKey Medical ID Card Information
+            const content = `iKey Emergency ID Card Information
 Generated: ${new Date().toLocaleString()}
 ================================
 

--- a/index.html
+++ b/index.html
@@ -2087,7 +2087,7 @@
                     <!-- Step 6: If Found Instructions -->
                     <div class="wizard-step" data-step="6">
                         <h2>If Found Instructions</h2>
-                        <p>What should someone do if they find your medical ID?</p>
+                        <p>What should someone do if they find your iKey Emergency ID?</p>
                         <p style="margin:10px 0; color: var(--secondary);">⚠️ This information will be visible to anyone who finds your card</p>
                         <div class="form-group">
                             <label>
@@ -2184,7 +2184,7 @@
 
                     <div class="qr-display-card">
   <div class="qr-header">
-    <h3>Medical ID - <span id="qr-name"></span></h3>
+    <h3>iKey Emergency ID - <span id="qr-name"></span></h3>
     <p class="instruction">Scan in emergency</p>
   </div>
   <div class="qr-code-wrapper">
@@ -4186,7 +4186,7 @@ END:VCALENDAR`;
 
             addInternalPage(pageId) {
                 const pages = {
-                    ikey: { name: 'Medical ID', icon: '🏥' },
+                    ikey: { name: 'iKey Emergency ID', icon: '🏥' },
                     'emergency': { name: 'Emergency', icon: '🚨' },
                     weather: { name: 'Weather', icon: '⛈️' },
                     wttin: { name: 'Resources', icon: '🏠' },
@@ -4843,6 +4843,10 @@ Generated: ${new Date().toLocaleString()}`;
         }
 
         function initializeDisplayView(data) {
+            // Make emergency ID info available globally and update home status card
+            displayData = data;
+            renderHomeStatus();
+
             // This sets up the regular display view that users can access via tabs
             document.getElementById('wizard-view').classList.add('hidden');
             document.getElementById('display-view').classList.remove('hidden');
@@ -4875,8 +4879,8 @@ Generated: ${new Date().toLocaleString()}`;
 
             // Email card (only if email exists)
             if (data.pe) {
-                const emailSubject = encodeURIComponent("Regarding your iKey Medical ID");
-                const emailBody = encodeURIComponent("Hi,\n\nI obtained your contact information through your iKey Medical ID.\n\n");
+                const emailSubject = encodeURIComponent("Regarding your iKey Emergency ID");
+                const emailBody = encodeURIComponent("Hi,\n\nI obtained your contact information through your iKey Emergency ID.\n\n");
                 commCards += `
         <div class="emergency-card" style="margin-bottom: 15px; cursor: pointer;">
             <a href="mailto:${data.pe}?subject=${emailSubject}&body=${emailBody}" style="text-decoration: none; color: inherit; display: block;">
@@ -5057,7 +5061,7 @@ Generated: ${new Date().toLocaleString()}`;
 
                 container.innerHTML += `
             <div class="status-card">
-                <div class="card-badge status-badge">🔒 MEDICAL ID ACTIVE</div>
+                <div class="card-badge status-badge">🔒 iKey Emergency ID ACTIVE</div>
                 <div class="card-content">
                     <div class="main-text">${displayData.n}</div>
                     <div class="sub-text">${alerts.length ? alerts.join(' • ') : 'No alerts'}</div>
@@ -5068,13 +5072,13 @@ Generated: ${new Date().toLocaleString()}`;
             } else {
                 container.innerHTML += `
             <div class="status-card warning">
-                <div class="card-badge status-badge">⚠️ NO MEDICAL ID</div>
+                <div class="card-badge status-badge">⚠️ NO iKey Emergency ID</div>
                 <div class="card-content">
-                    <div class="main-text">Create Your Medical ID</div>
+                    <div class="main-text">Create Your iKey Emergency ID</div>
                     <div class="sub-text">Tap to add emergency information</div>
                 </div>
                 <button class="btn btn-primary" style="margin-top: 12px; width: 100%;" onclick="switchTab('ikey')">
-                    Create Medical ID
+                    Create iKey Emergency ID
                 </button>
             </div>
         `;


### PR DESCRIPTION
## Summary
- refresh home status card after initializing emergency ID to avoid "create" prompt
- rebrand all UI mentions from "Medical ID" to "iKey Emergency ID"
- update tagline and card content strings

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile scripts/generate_translation_doc.py`


------
https://chatgpt.com/codex/tasks/task_b_68c59e5add08833293eeb4a9464cec33