### PR TITLE
Enable direct calling for emergency settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2690,21 +2690,21 @@
 
                 <div class="settings-section">
                     <h3 style="margin-bottom: 15px; color: var(--primary);" data-i18n="settings.emergencyResources">Emergency Resources</h3>
-                    <div class="settings-item" onclick="alert('Suicide & Crisis Lifeline: 988')">
+                    <a href="tel:988" class="settings-item">
                         <div>
                             <div style="font-weight: 600;" data-i18n="settings.crisisSupport">💬 Crisis Support</div>
                             <div style="font-size: 0.85rem; color: var(--secondary); margin-top: 5px;" data-i18n="settings.crisisSupportDesc">Mental health and crisis resources</div>
                         </div>
                         <span style="color: var(--secondary);">→</span>
-                    </div>
+                    </a>
 
-                    <div class="settings-item" onclick="alert('Poison Control: 1-800-222-1222')">
+                    <a href="tel:18002221222" class="settings-item">
                         <div>
                             <div style="font-weight: 600;" data-i18n="settings.poisonControl">☠️ Poison Control</div>
                             <div style="font-size: 0.85rem; color: var(--secondary); margin-top: 5px;" data-i18n="settings.poisonControlDesc">24/7 poison emergency help</div>
                         </div>
                         <span style="color: var(--secondary);">→</span>
-                    </div>
+                    </a>
                     <a href="https://team211.communityos.org/homepage-uwgn" target="_blank" class="settings-item">
                         <div>
                             <div style="font-weight: 600;">📞 211</div>


### PR DESCRIPTION
## Summary
- Replace emergency settings popups with tel links for Crisis Support and Poison Control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c59f5a798c8332855b4b68b59b1efc