### PR TITLE
feat: add resources dropdown in nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,6 +210,11 @@
             width: auto;
         }
 
+        .dropdown {
+            position: relative;
+            flex: 0 0 auto;
+        }
+
         .dropdown-menu {
             position: absolute;
             background: white;
@@ -217,7 +222,7 @@
             border-radius: 4px;
             padding: 4px;
             top: 100%;
-            right: 0;
+            left: 0;
             display: flex;
             flex-direction: column;
             z-index: 99;
@@ -1795,10 +1800,17 @@
             <span class="tab-icon">⛈️</span>
             <span class="tab-label" data-i18n="nav.weather">Weather</span>
         </button>
-        <button class="tab-btn" onclick="toggleResourceMenu()" aria-label="More">
-            <span class="tab-icon">📚</span>
-            <span class="tab-label">More</span>
-        </button>
+        <div class="dropdown">
+            <button class="tab-btn" onclick="toggleResourceMenu()" aria-label="resources">
+                <span class="tab-icon">📚</span>
+                <span class="tab-label">resources</span>
+            </button>
+            <div id="resource-menu" class="dropdown-menu hidden">
+                <button onclick="switchTab('wttin'); toggleResourceMenu();" data-i18n="nav.wttin">Resources</button>
+                <button onclick="switchTab('meals'); toggleResourceMenu();" data-i18n="nav.meals">Meals</button>
+                <button onclick="switchTab('apps'); toggleResourceMenu();">Proton</button>
+            </div>
+        </div>
         <button id="dispatch-tab-btn" class="tab-btn" data-tab="dispatch" style="display: none;" onclick="switchTab('dispatch')" aria-label="Dispatch" data-i18n-aria="nav.dispatch">
             <span class="tab-icon">📡</span>
             <span class="tab-label" data-i18n="nav.dispatch">Dispatch</span>
@@ -1808,12 +1820,6 @@
             <span class="tab-label" data-i18n="nav.settings">Settings</span>
         </button>
         </nav>
-        <!-- Hidden dropdown for grouped resources -->
-        <div id="resource-menu" class="dropdown-menu hidden">
-            <button onclick="switchTab('wttin'); toggleResourceMenu();" data-i18n="nav.wttin">Resources</button>
-            <button onclick="switchTab('meals'); toggleResourceMenu();" data-i18n="nav.meals">Meals</button>
-            <button onclick="switchTab('apps'); toggleResourceMenu();">Proton</button>
-        </div>
     </div>
 
     <!-- Home Tab -->


### PR DESCRIPTION
## Summary
- Replace "More" tab with "resources" and group related links beneath it
- Style dropdown to appear under the resources button for standard nav behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5a27499d4833286b0e7dcbc53df0e