### PR TITLE
Enable clickable hotline phone and text options

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -351,7 +351,8 @@
             "cards": {
                 "lifeline": {
                     "name": "988 Suicide & Crisis Lifeline",
-                    "call": "Call or Text 988"
+                    "call": "Call 988",
+                    "text": "Text 988"
                 },
                 "veterans": {
                     "name": "Veterans Crisis Line",

--- a/hotlines.html
+++ b/hotlines.html
@@ -238,7 +238,8 @@
         <div class="hotlines-grid">
             <div class="hotline-card">
                 <div class="hotline-name" data-i18n="hotlines.cards.lifeline.name">988 Suicide & Crisis Lifeline</div>
-                <a href="tel:988" class="phone-number" data-i18n="hotlines.cards.lifeline.call"><span class="phone-icon">📞</span> Call or Text 988</a>
+                <a href="tel:988" class="phone-number" data-i18n="hotlines.cards.lifeline.call"><span class="phone-icon">📞</span> Call 988</a>
+                <a href="sms:988" class="text-option" data-i18n="hotlines.cards.lifeline.text"><span class="phone-icon">💬</span> Text 988</a>
                 <div class="available-247" data-i18n="hotlines.labels.available247">Available 24/7</div>
                 <div class="detail-section">
                     <div class="detail-item">
@@ -254,7 +255,7 @@
             <div class="hotline-card">
                 <div class="hotline-name" data-i18n="hotlines.cards.veterans.name">Veterans Crisis Line</div>
                 <a href="tel:988" class="phone-number" data-i18n="hotlines.cards.veterans.call"><span class="phone-icon">📞</span> 988, Press 1</a>
-                <div class="text-option" data-i18n="hotlines.cards.veterans.text">Text: 838255</div>
+                <a href="sms:838255" class="text-option" data-i18n="hotlines.cards.veterans.text"><span class="phone-icon">💬</span> Text: 838255</a>
                 <div class="available-247" data-i18n="hotlines.labels.available247">Available 24/7</div>
                 <div class="detail-section">
                     <div class="detail-item">
@@ -269,7 +270,7 @@
             <div class="hotline-card">
                 <div class="hotline-name" data-i18n="hotlines.cards.domestic.name">National Domestic Violence Hotline</div>
                 <a href="tel:18007997233" class="phone-number" data-i18n="hotlines.cards.domestic.call"><span class="phone-icon">📞</span> 1-800-799-7233</a>
-                <div class="text-option" data-i18n="hotlines.cards.domestic.text">Text START to 88788</div>
+                <a href="sms:88788?body=START" class="text-option" data-i18n="hotlines.cards.domestic.text"><span class="phone-icon">💬</span> Text START to 88788</a>
                 <div class="available-247" data-i18n="hotlines.labels.available247">Available 24/7</div>
                 <div class="detail-section">
                     <div class="detail-item">
@@ -285,7 +286,7 @@
             <div class="hotline-card">
                 <div class="hotline-name" data-i18n="hotlines.cards.rainn.name">RAINN Sexual Assault Hotline</div>
                 <a href="tel:18006564673" class="phone-number" data-i18n="hotlines.cards.rainn.call"><span class="phone-icon">📞</span> 1-800-656-4673</a>
-                <div class="text-option" data-i18n="hotlines.cards.rainn.text">Online chat: rainn.org</div>
+                <a href="https://rainn.org" class="text-option" target="_blank" rel="noopener" data-i18n="hotlines.cards.rainn.text"><span class="phone-icon">💬</span> Online chat: rainn.org</a>
                 <div class="available-247" data-i18n="hotlines.labels.available247">Available 24/7</div>
                 <div class="detail-section">
                     <div class="detail-item">
@@ -376,7 +377,7 @@
             <div class="hotline-card">
                 <div class="hotline-name" data-i18n="hotlines.cards.trafficking.name">Human Trafficking Hotline</div>
                 <a href="tel:18883737888" class="phone-number" data-i18n="hotlines.cards.trafficking.call"><span class="phone-icon">📞</span> 1-888-373-7888</a>
-                <div class="text-option" data-i18n="hotlines.cards.trafficking.text">Text: 233733</div>
+                <a href="sms:233733" class="text-option" data-i18n="hotlines.cards.trafficking.text"><span class="phone-icon">💬</span> Text: 233733</a>
                 <div class="available-247" data-i18n="hotlines.labels.available247">Available 24/7</div>
                 <div class="detail-section">
                     <div class="detail-item">


### PR DESCRIPTION
## Summary
- Add separate call and text links for the 988 Suicide & Crisis Lifeline
- Turn text options into clickable links for Veterans, Domestic Violence, RAINN, and Human Trafficking hotlines
- Update translation terms to support new 988 text link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5a49d86508332aa983af989e9a5b0