### PR TITLE
Close resource menu after selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1888,19 +1888,19 @@
         </nav>
         <!-- Hidden dropdown for grouped resources -->
         <div id="resource-menu" class="dropdown-menu hidden">
-            <button onclick="switchTab('wttin'); toggleResourceMenu();">
+            <button onclick="switchTab('wttin')">
                 <span>🏠</span>
                 <span>Where To Turn in Nashville</span>
             </button>
-            <button onclick="switchTab('hotlines'); toggleResourceMenu();">
+            <button onclick="switchTab('hotlines')">
                 <span>☎️</span>
                 <span data-i18n="nav.hotlines">Hotlines</span>
             </button>
-            <button onclick="switchTab('meals'); toggleResourceMenu();">
+            <button onclick="switchTab('meals')">
                 <span>🍽️</span>
                 <span data-i18n="nav.meals">Meals</span>
             </button>
-            <button onclick="switchTab('apps'); toggleResourceMenu();">
+            <button onclick="switchTab('apps')">
                 <span>🚀</span>
                 <span>Proton</span>
             </button>
@@ -2942,6 +2942,8 @@
             const resourceBtn = document.querySelector(".tab-btn[onclick*='toggleResourceMenu']");
             if (menu) {
                 menu.classList.add('hidden');
+                document.removeEventListener('click', handleOutsideMenuClick);
+                document.removeEventListener('keydown', handleEscapeKey);
             }
             resourceBtn?.classList.remove('menu-open');
 


### PR DESCRIPTION
## Summary
- Ensure resource dropdown options only switch tabs without reopening the menu
- Clean up resource menu listeners when switching tabs to hide menu reliably

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68c5abd137a083329e15883560f19e5f