### PR TITLE
feat: add key ownership detection and restore

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -263,7 +263,7 @@
             "readingGlasses": "Reading Glasses",
             "whatsThis": "What's this say?",
             "grandma": "Grandma",
-            "tabVisibility": "Tab Visibility",
+            "tabVisibility": "Customize Home Tabs",
             "tabHome": "🏠 Home",
             "tabiKey": "🏥 iKey",
             "tabWeather": "⛈️ Weather",

--- a/index.html
+++ b/index.html
@@ -89,6 +89,21 @@
             color: var(--secondary);
         }
 
+        .key-banner {
+            background: #e0e7ff;
+            text-align: center;
+            padding: 8px 10px;
+            font-weight: 600;
+        }
+
+        .key-banner.hidden {
+            display: none;
+        }
+
+        .key-banner .btn {
+            margin-left: 10px;
+        }
+
         #language-toggle {
             position: absolute;
             top: 10px;
@@ -1850,6 +1865,11 @@
         <p data-i18n="appTagline">Secure Location & Personal Safety Hub</p>
     </div>
 
+    <div id="key-banner" class="key-banner hidden">
+        <span id="key-banner-text"></span>
+        <button id="back-to-my-key" class="btn btn-secondary hidden" onclick="returnToMyKey()">Back to my key</button>
+    </div>
+
     <!-- Tab Navigation -->
     <div class="nav-wrapper">
         <nav class="tab-nav">
@@ -2784,7 +2804,7 @@
                 </div>
                 
                 <div class="settings-section">
-                    <h3 style="margin-bottom: 15px; color: var(--primary);" data-i18n="settings.tabVisibility">Tab Visibility</h3>
+                    <h3 style="margin-bottom: 15px; color: var(--primary);" data-i18n="settings.tabVisibility">Customize Home Tabs</h3>
                     <div class="settings-item" style="cursor: default;">
                         <div>
                             <div style="font-weight: 600;" data-i18n="nav.emergency">🚨 Emergency</div>
@@ -3418,6 +3438,14 @@
 
             window.history.replaceState(null, '', url);
 
+            localStorage.setItem('myKeyData', compressed);
+            if (cleanData.pe) localStorage.setItem('myKeyEmail', cleanData.pe);
+            if (cleanData.n) localStorage.setItem('myKeyName', cleanData.n);
+            displayData = cleanData;
+            isOwnKey = true;
+            renderHomeStatus();
+            updateKeyBanner();
+
             document.getElementById('wizard-view').classList.add('hidden');
             document.getElementById('qr-view').classList.remove('hidden');
 
@@ -3937,12 +3965,13 @@ END:VCALENDAR`;
                 let html = '<div class="favorites-container">';
                 html += '<div class="favorites' + (this.editMode ? ' editing' : '') + '" id="favorites">';
 
+                const qrLabel = (displayData && !isOwnKey) ? (displayData.n || 'QR') : 'My QR';
                 html += `
                     <div class="favorite qr-widget" data-action="qr" draggable="false">
                         <div class="icon-wrapper">
                             <img src="https://cdn.iconscout.com/icon/free/png-256/free-qr-code-icon-svg-png-download-1569017.png" alt="QR Code Icon" class="icon-img" onerror="this.style.display='none'; this.parentElement.innerHTML='🔳';">
                         </div>
-                        <div class="label icon-label">My QR</div>
+                        <div class="label icon-label">${qrLabel}</div>
                     </div>
                 `;
 
@@ -4905,6 +4934,7 @@ Generated: ${new Date().toLocaleString()}`;
         }
 
         let displayData = null;
+        let isOwnKey = false;
 
         function showEmergencyModal(data) {
             const modal = document.getElementById('emergency-modal');
@@ -5009,6 +5039,7 @@ Generated: ${new Date().toLocaleString()}`;
             // Make emergency ID info available globally and update home status card
             displayData = data;
             renderHomeStatus();
+            updateKeyBanner();
 
             // This sets up the regular display view that users can access via tabs
             document.getElementById('wizard-view').classList.add('hidden');
@@ -5260,6 +5291,36 @@ Generated: ${new Date().toLocaleString()}`;
             }
         } // This closing brace was missing!
 
+        function updateKeyBanner() {
+            const banner = document.getElementById('key-banner');
+            const textEl = document.getElementById('key-banner-text');
+            const backBtn = document.getElementById('back-to-my-key');
+            if (!banner || !textEl) return;
+            if (!displayData) {
+                banner.classList.add('hidden');
+                return;
+            }
+            const myEmail = localStorage.getItem('myKeyEmail');
+            const myHash = localStorage.getItem('myKeyData');
+            isOwnKey = myEmail && displayData.pe && displayData.pe === myEmail;
+            textEl.textContent = isOwnKey ? 'Viewing your own key' : "Viewing someone else's key - read only";
+            if (isOwnKey) {
+                backBtn.classList.add('hidden');
+            } else {
+                if (myHash) backBtn.classList.remove('hidden');
+                else backBtn.classList.add('hidden');
+            }
+            banner.classList.remove('hidden');
+            if (bookmarkManager) bookmarkManager.render();
+        }
+
+        function returnToMyKey() {
+            const myHash = localStorage.getItem('myKeyData');
+            if (myHash) {
+                window.location.hash = myHash;
+                location.reload();
+            }
+        }
 
         // Share Location Tab Functions
         function initShareTab() {
@@ -5712,6 +5773,7 @@ Generated: ${new Date().toLocaleString()}`;
                     }
 
                     displayData = data;
+                    updateKeyBanner();
 
                     const scanKey = `scanned_${hash}`;
                     if (!localStorage.getItem(scanKey)) {
@@ -5727,6 +5789,8 @@ Generated: ${new Date().toLocaleString()}`;
                     console.error('Failed to parse URL data:', e);
                 }
             }
+
+            updateKeyBanner();
             
             // Handle enter key in weather search
             document.getElementById('city-input').addEventListener('keypress', function(e) {


### PR DESCRIPTION
## Summary
- detect when a scanned key matches the local user using stored email
- show banner and "Back to my key" button when viewing another user's key
- rename "Tab visibility" to "Customize Home Tabs" and swap "My QR" label with contact name on scanned keys

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5cf60187c8332952ae46646394cfc