### PR TITLE
Add privacy info page and location consent modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ iKey is a lightweight, client‑side web app that keeps your location and key pe
 
 The project is a collection of static HTML files. Open `index.html` directly in a browser or serve the folder from any static web host.
 
+## Deployment
+
+For production use, host the files on a neutral domain that doesn't identify individuals, such as `ikey.yourorg.org`.
+
 ## Development
 
 The repository has no build step. Edits can be made directly to the HTML or translation files. A helper script in `scripts/generate_translation_doc.py` regenerates the translation document when new terms are added.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title data-i18n="about.title">About & Privacy</title>
+    <script src="scripts/translate.js"></script>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: #f8fafc;
+            min-height: 100vh;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background: #fff;
+            padding: 20px;
+            border-radius: 16px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        h1 { font-size: 1.8rem; margin-bottom: 16px; }
+        p { margin-bottom: 12px; }
+        a { color: var(--primary, #3b82f6); }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1 data-i18n="about.heading">About & Privacy</h1>
+        <p data-i18n="about.storage">iKey runs entirely in your browser. Favorites and recent locations are saved in localStorage on your device.</p>
+        <p data-i18n="about.offline">Once loaded, the app works offline and no data leaves your device unless you choose to share it.</p>
+        <p data-i18n="about.clear">To clear your data, open your browser settings and remove site data for this page or use the "Clear browsing data" option.</p>
+        <p data-i18n="about.back"><a href="index.html">Back to Home</a></p>
+    </div>
+</body>
+</html>

--- a/home.html
+++ b/home.html
@@ -168,6 +168,10 @@
     <div class="loading"></div>
   </div>
 
+  <div style="text-align:center; padding: 16px;">
+    <a href="about.html" data-i18n="home.aboutLink">About &amp; Privacy</a>
+  </div>
+
   <div id="toast" class="toast" style="display: none"></div>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -1918,6 +1918,10 @@
                 <!-- Populated by JavaScript -->
             </div>
 
+            <div style="text-align: center; margin-top: 20px;">
+                <a href="about.html" data-i18n="home.aboutLink">About &amp; Privacy</a>
+            </div>
+
         </div>
     </div>
 
@@ -2313,7 +2317,7 @@
                 </div>
             </div>
         </div>
-    </div>
+</div>
 
 <!-- QR Code Modal -->
 <div id="qr-modal" class="modal hidden">
@@ -2325,11 +2329,27 @@
     </div>
 </div>
 
+<!-- Location Permission Modal -->
+<div id="location-modal" class="modal hidden">
+    <div class="modal-content" style="max-width: 500px;">
+        <div class="modal-header" style="padding: 20px; border-bottom: 1px solid var(--border);">
+            <h3 data-i18n="location.shareTitle" style="margin: 0;">Share location?</h3>
+        </div>
+        <div style="padding: 20px;">
+            <p data-i18n="location.shareDesc">Your GPS coordinates stay on this device unless you choose to send them. Allow access?</p>
+            <div class="modal-actions" style="margin-top: 20px; display: flex; gap: 10px; justify-content: flex-end;">
+                <button class="btn btn-secondary" onclick="cancelLocationRequest()" data-i18n="location.cancel">Don't Share</button>
+                <button class="btn btn-primary" onclick="confirmLocationRequest()" data-i18n="location.share">Share Location</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Emergency Services Tab -->
 <div id="emergency" class="tab-content">
         <div class="container">
             <div class="location-share-tip" style="margin-bottom: 20px;">
-                <button class="btn btn-secondary" onclick="getLocation()">Enable Location Sharing</button>
+                <button class="btn btn-secondary" onclick="showLocationModal()">Enable Location Sharing</button>
                 <p style="font-size: 0.85rem; color: var(--secondary); margin-top: 5px;">Helps get your precise location to give operators.</p>
             </div>
 
@@ -2961,7 +2981,7 @@
                 }
             } else if (tabName === 'emergency') {
                 if (!window.emergencyLoaded) {
-                    getLocation();
+                    showLocationModal();
                     window.emergencyLoaded = true;
                 }
             } else if (tabName === 'share') {
@@ -4640,6 +4660,28 @@ Generated: ${new Date().toLocaleString()}`;
             
             document.getElementById('emergency-loading').style.display = 'none';
             document.getElementById('emergency-content').style.display = 'block';
+        }
+
+        function showLocationModal() {
+            const modal = document.getElementById('location-modal');
+            if (modal) {
+                modal.classList.remove('hidden');
+            }
+        }
+
+        function confirmLocationRequest() {
+            const modal = document.getElementById('location-modal');
+            if (modal) {
+                modal.classList.add('hidden');
+            }
+            getLocation();
+        }
+
+        function cancelLocationRequest() {
+            const modal = document.getElementById('location-modal');
+            if (modal) {
+                modal.classList.add('hidden');
+            }
         }
 
         function getLocation() {


### PR DESCRIPTION
## Summary
- Add About & Privacy page detailing storage, offline use, and clearing data
- Link to About & Privacy from home screen
- Require explicit consent before accessing geolocation data
- Document hosting on a neutral domain in deployment instructions

## Testing
- `npm test` (fails: could not find package.json)


------
https://chatgpt.com/codex/tasks/task_b_68c5cf6155c88332a1dbdd272137079d