### PR TITLE
Add backup export and key management workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ The repository has no build step. Edits can be made directly to the HTML or tran
 
 When adding DOM elements at runtime (wizards, modals, etc.), call the global `translateFragment(rootElement)` helper from `scripts/translate.js`. It applies `data-i18n*` translations to the supplied subtree so new UI fragments are translated immediately.
 
+## Contributing
+
+### Accessibility
+
+- Use semantic HTML and meaningful ARIA roles.
+- Provide descriptive `alt` text for all images and icons.
+- Ensure keyboard navigation and sufficient color contrast when introducing new UI.
+
+### Privacy
+
+- Keep all data client-side; avoid adding analytics or external trackers.
+- Clearly communicate that information is stored in `localStorage` without encryption.
+- Only collect data that is essential for emergency use and allow users to remove it.
+
+### Translations
+
+- Add new strings to `TRANSLATION_TERMS.md`.
+- Run `python scripts/generate_translation_doc.py` to update the compiled document.
+- Provide translations for supported languages when possible.
+
 ## License
 
 This project is provided as a public good. Use at your own discretion and always verify critical information before sharing it in emergencies.

--- a/card.html
+++ b/card.html
@@ -1107,7 +1107,7 @@
 
         function displayPhoto(data) {
             const preview = document.getElementById('photoPreview');
-            preview.innerHTML = `<img src="${data}" alt="Photo">`;
+            preview.innerHTML = `<img src="${data}" alt="Photo preview">`;
             document.getElementById('removeBtn').style.display = 'block';
 
             updateCardDisplay();
@@ -1135,7 +1135,7 @@
             if (photoData) {
                 idSection.classList.remove('single');
                 cardPhotoContainer.style.display = 'block';
-                cardPhotoContainer.innerHTML = `<img class="card-photo" src="${photoData}">`;
+                cardPhotoContainer.innerHTML = `<img class="card-photo" src="${photoData}" alt="Card photo">`;
             } else {
                 idSection.classList.add('single');
                 cardPhotoContainer.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -2273,6 +2273,8 @@
                                     <button onclick="emailInfo()">✉️ Email</button>
                                     <button onclick="copyLinkForEmail()">📋 Copy</button>
                                     <button onclick="saveQRImage()">💾 Save</button>
+                                    <button onclick="exportBackup()">📦 Backup</button>
+                                    <button onclick="createNewKey()">🔑 New Key</button>
                                 </div>
                             </div>
                             <div id="share-history" style="margin-top:10px; font-size:0.9rem; color: var(--secondary);"></div>
@@ -3593,6 +3595,43 @@
             logShare('qr_code', null, 'sms');
         }
 
+        function exportBackup() {
+            const keyData = {};
+            for (let i = 0; i < localStorage.length; i++) {
+                const k = localStorage.key(i);
+                if (k.startsWith(storagePrefix + '_')) {
+                    keyData[k.slice(storagePrefix.length + 1)] = localStorage.getItem(k);
+                }
+            }
+            const bookmarks = JSON.parse(localStorage.getItem('homeBookmarks') || '[]');
+            const backup = { key: storagePrefix, data: keyData, bookmarks };
+            const text = JSON.stringify(backup, null, 2);
+            const sendEmail = confirm('Send backup via email? Cancel for text.');
+            const method = sendEmail ? 'email' : 'sms';
+            const uri = sendEmail
+                ? `mailto:?subject=${encodeURIComponent('iKey Backup')}&body=${encodeURIComponent(text)}`
+                : (/iPhone|iPad|iPod/.test(navigator.userAgent)
+                    ? `sms:&body=${encodeURIComponent(text)}`
+                    : `sms:?body=${encodeURIComponent(text)}`);
+            window.location.href = uri;
+            logShare('backup', null, method);
+        }
+
+        function createNewKey() {
+            const newKey = prompt('Enter new key name');
+            if (!newKey) return;
+            for (let i = 0; i < localStorage.length; i++) {
+                const k = localStorage.key(i);
+                if (k.startsWith(storagePrefix + '_')) {
+                    const suffix = k.substring(storagePrefix.length + 1);
+                    localStorage.setItem(`${newKey}_${suffix}`, localStorage.getItem(k));
+                }
+            }
+            alert('New key created. Reprint and redistribute your card.');
+            window.location.href = `${window.location.pathname}#${encodeURIComponent(newKey)}`;
+            window.location.reload();
+        }
+
         function shareQR(target = 'qrcode') {
             // Allow sharing even if a QR code hasn't been generated yet.
             // The previous implementation required an existing QR canvas and
@@ -3746,7 +3785,7 @@
             const qrImage = getQRCodeDataURL();
             const { text: textSummary, pdf } = generateMedicalSummary();
             const vCard = generateVCard();
-            const html = `<html><body><img src='${qrImage}'/><pre>${textSummary}</pre></body></html>`;
+            const html = `<html><body><img src='${qrImage}' alt='QR code'><pre>${textSummary}</pre></body></html>`;
             return { qrImage, textSummary, vCard, html, pdf };
         }
 


### PR DESCRIPTION
## Summary
- add manual backup export of bookmarks and key data via text or email
- allow creating new keys pre-filled from existing data with warning to reprint
- document accessibility, privacy, and translation guidelines for contributors

## Testing
- `python -m py_compile scripts/generate_translation_doc.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5cf66fbe883329cdc4990690f95eb