### PR TITLE
Add alt text to card photo image

### DIFF
--- a/card.html
+++ b/card.html
@@ -1135,7 +1135,7 @@
             if (photoData) {
                 idSection.classList.remove('single');
                 cardPhotoContainer.style.display = 'block';
-                cardPhotoContainer.innerHTML = `<img class="card-photo" src="${photoData}" alt="Card photo">`;
+                cardPhotoContainer.innerHTML = `<img class="card-photo" src="${photoData}" alt="User photo">`;
             } else {
                 idSection.classList.add('single');
                 cardPhotoContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- add descriptive alt text to card photo image for better accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d1a454908332ab4570a6d1b660fb