### PR TITLE
Use semantic buttons for favorites

### DIFF
--- a/home.html
+++ b/home.html
@@ -87,6 +87,8 @@
       align-items: center;
       justify-content: center;
       cursor: pointer;
+      border: none;
+      padding: 0;
     }
     .favorite .delete {
       display: none;
@@ -95,12 +97,14 @@
       right: -8px;
       width: 24px;
       height: 24px;
-      border: none;
       border-radius: 50%;
       background: var(--emergency-color);
       color: white;
+      cursor: pointer;
+      align-items: center;
+      justify-content: center;
     }
-    .favorites.editing .delete { display: block; }
+    .favorites.editing .delete { display: flex; }
     .favorite.add-favorite { font-size: 32px; }
 
     .loading {
@@ -310,18 +314,18 @@
         return `<div class="text-body">${t('home.noFavorites', 'No favorites yet')}</div>`;
       }
       const listHtml = details.map(d => `
-            <div class="favorite" draggable="${editMode}" data-index="${d.index}" data-url="${d.info.url}">
+            <button class="favorite" type="button" draggable="${editMode}" data-index="${d.index}" data-url="${d.info.url}" aria-label="${d.info.name}">
               <span class="icon"><img src="${d.info.icon}" alt="${d.info.name}" width="32" height="32"></span>
               <span class="label">${d.info.name}</span>
-              <button class="delete" onclick="event.stopPropagation(); deleteFavorite(${d.index})">✕</button>
-            </div>
+              <span class="delete" role="button" aria-label="${t('common.delete', 'Delete')}" tabindex="0">✕</span>
+            </button>
           `).join('');
-      const addTile = editMode ? '<div class="favorite add-favorite" onclick="addFavorite()">+</div>' : '';
+      const addTile = editMode ? `<button type="button" class="favorite add-favorite" aria-label="${t('home.addFavorite', 'Add Favorite')}"><span aria-hidden="true">+</span></button>` : '';
       return `
         <div class="favorites ${editMode ? 'editing' : ''}" id="favorites">
           ${listHtml}${addTile}
         </div>
-        ${editMode ? `<div class="button-group"><button onclick="exitEdit()">${t('common.done', 'Done')}</button></div>` : ''}
+        ${editMode ? `<div class="button-group"><button type="button" class="done-btn">${t('common.done', 'Done')}</button></div>` : ''}
       `;
     }
 
@@ -369,6 +373,21 @@
         item.addEventListener('mouseleave', cancelPress);
         item.addEventListener('touchend', cancelPress);
 
+        const del = item.querySelector('.delete');
+        if (del) {
+          del.addEventListener('click', e => {
+            e.stopPropagation();
+            deleteFavorite(index);
+          });
+          del.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              e.stopPropagation();
+              deleteFavorite(index);
+            }
+          });
+        }
+
         item.addEventListener('click', () => {
           if (editMode) return;
           const url = item.dataset.url;
@@ -397,6 +416,16 @@
           moveFavorite(from, to);
         });
       });
+
+      const addBtn = container.querySelector('.add-favorite');
+      if (addBtn) {
+        addBtn.addEventListener('click', addFavorite);
+      }
+
+      const doneBtn = document.querySelector('.done-btn');
+      if (doneBtn) {
+        doneBtn.addEventListener('click', exitEdit);
+      }
     }
 
     function addFavorite() {

--- a/index.html
+++ b/index.html
@@ -1290,6 +1290,9 @@
             cursor: pointer;
             -webkit-tap-highlight-color: transparent;
             user-select: none;
+            border: none;
+            background: none;
+            padding: 0;
         }
 
         .favorite .icon-wrapper {
@@ -1371,6 +1374,9 @@
         .add-bookmark-btn {
             width: 75px;
             cursor: pointer;
+            border: none;
+            background: none;
+            padding: 0;
         }
 
         .add-bookmark-btn .icon-wrapper {
@@ -4231,12 +4237,12 @@ END:VCALENDAR`;
 
                 const qrLabel = (displayData && !isOwnKey) ? (displayData.n || 'QR') : 'My QR';
                 html += `
-                    <div class="favorite qr-widget" data-action="qr" draggable="false">
+                    <button class="favorite qr-widget" type="button" data-action="qr" draggable="false" aria-label="${qrLabel}">
                         <div class="icon-wrapper">
                             <img src="https://cdn.iconscout.com/icon/free/png-256/free-qr-code-icon-svg-png-download-1569017.png" alt="QR Code Icon" class="icon-img" onerror="this.style.display='none'; this.parentElement.innerHTML='🔳';">
                         </div>
                         <div class="label icon-label">${qrLabel}</div>
-                    </div>
+                    </button>
                 `;
 
                 this.bookmarks.forEach((bookmark, index) => {
@@ -4244,11 +4250,13 @@ END:VCALENDAR`;
                     if (info) {
                         const isEmoji = this.isEmoji(info.icon);
                         html += `
-                    <div class="favorite"
-                         data-index="${index}" 
+                    <button class="favorite"
+                         type="button"
+                         data-index="${index}"
                          draggable="${this.editMode}"
-                         data-url="${info.url || ''}">
-                        <div class="delete-btn" onclick="event.stopPropagation(); bookmarkManager.removeBookmark(${index})">×</div>
+                         data-url="${info.url || ''}"
+                         aria-label="${info.name}">
+                        <div class="delete-btn" role="button" aria-label="Remove bookmark" tabindex="0">×</div>
                         <div class="icon-wrapper">
                             ${isEmoji ?
                                 `<span class="icon-emoji">${info.icon}</span>` :
@@ -4256,22 +4264,22 @@ END:VCALENDAR`;
                             }
                         </div>
                         <div class="label icon-label">${info.name}</div>
-                    </div>
+                    </button>
                 `;
                     }
                 });
 
                 html += `
-                    <div class="add-bookmark-btn" onclick="bookmarkManager.openAddModal()">
+                    <button class="add-bookmark-btn" type="button">
                         <div class="icon-wrapper">+</div>
                         <div class="label">Add</div>
-                    </div>
+                    </button>
                 `;
 
                 html += '</div>';
 
                 if (this.editMode) {
-                    html += '<button class="done-editing-btn" onclick="bookmarkManager.exitEditMode()">Done</button>';
+                    html += '<button class="done-editing-btn" type="button">Done</button>';
                 }
 
                 html += '</div>';
@@ -4305,6 +4313,21 @@ END:VCALENDAR`;
                     fav.addEventListener('mousemove', () => this.cancelLongPress());
                     fav.addEventListener('mouseleave', () => this.cancelLongPress());
 
+                    const del = fav.querySelector('.delete-btn');
+                    if (del) {
+                        del.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            this.removeBookmark(parseInt(fav.dataset.index));
+                        });
+                        del.addEventListener('keydown', (e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                this.removeBookmark(parseInt(fav.dataset.index));
+                            }
+                        });
+                    }
+
                     fav.addEventListener('click', (e) => this.handleClick(e));
 
                     if (this.editMode) {
@@ -4314,6 +4337,16 @@ END:VCALENDAR`;
                         fav.addEventListener('dragend', (e) => this.handleDragEnd(e));
                     }
                 });
+
+                const addBtn = document.querySelector('.add-bookmark-btn');
+                if (addBtn) {
+                    addBtn.addEventListener('click', () => this.openAddModal());
+                }
+
+                const doneBtn = document.querySelector('.done-editing-btn');
+                if (doneBtn) {
+                    doneBtn.addEventListener('click', () => this.exitEditMode());
+                }
             }
 
             handleTouchStart(e) {


### PR DESCRIPTION
## Summary
- Replace clickable `div` favorites and add-bookmark controls with semantic `<button>` elements and add accessible labels
- Attach event handlers via JavaScript instead of inline `onclick`
- Ensure favorites and delete controls are keyboard operable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d1a6d4348332853244cc5617eebb