### PR TITLE
Improve modal accessibility focus management

### DIFF
--- a/index.html
+++ b/index.html
@@ -2423,7 +2423,7 @@
 </div>
 
 <!-- QR Code Modal -->
-<div id="qr-modal" class="modal hidden">
+<div id="qr-modal" class="modal hidden" role="dialog" aria-modal="true" aria-hidden="true" tabindex="-1">
     <div class="modal-content qr-modal-content">
         <div id="qr-modal-code"></div>
         <div class="modal-actions">
@@ -2433,15 +2433,16 @@
 </div>
 
 <!-- Location Permission Modal -->
-<div id="location-modal" class="modal hidden">
+<div id="location-modal" class="modal hidden" role="dialog" aria-modal="true" aria-hidden="true" tabindex="-1">
     <div class="modal-content" style="max-width: 500px;">
         <div class="modal-header" style="padding: 20px; border-bottom: 1px solid var(--border);">
             <h3 data-i18n="location.shareTitle" style="margin: 0;">Share location?</h3>
+            <button class="modal-close" onclick="closeLocationModal()">×</button>
         </div>
         <div style="padding: 20px;">
             <p data-i18n="location.shareDesc">Your GPS coordinates stay on this device unless you choose to send them. Allow access?</p>
             <div class="modal-actions" style="margin-top: 20px; display: flex; gap: 10px; justify-content: flex-end;">
-                <button class="btn btn-secondary" onclick="cancelLocationRequest()" data-i18n="location.cancel">Don't Share</button>
+                <button class="btn btn-secondary" onclick="closeLocationModal()" data-i18n="location.cancel">Close</button>
                 <button class="btn btn-primary" onclick="confirmLocationRequest()" data-i18n="location.share">Share Location</button>
             </div>
         </div>
@@ -4085,7 +4086,54 @@ let dataListenersSet = false;
             }
         }
 
+        let lastFocusedElement = null;
+
+        function trapFocus(modal, closeCallback) {
+            const focusableSelectors = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+            function handleKeydown(e) {
+                if (e.key === 'Escape') {
+                    e.preventDefault();
+                    closeCallback();
+                    return;
+                }
+                if (e.key !== 'Tab') return;
+                const focusableElements = modal.querySelectorAll(focusableSelectors);
+                const firstFocusable = focusableElements[0];
+                const lastFocusable = focusableElements[focusableElements.length - 1];
+                if (focusableElements.length === 0) {
+                    e.preventDefault();
+                    return;
+                }
+                if (e.shiftKey) {
+                    if (document.activeElement === firstFocusable) {
+                        e.preventDefault();
+                        lastFocusable.focus();
+                    }
+                } else {
+                    if (document.activeElement === lastFocusable) {
+                        e.preventDefault();
+                        firstFocusable.focus();
+                    }
+                }
+            }
+            modal.addEventListener('keydown', handleKeydown);
+            modal._handleKeydown = handleKeydown;
+            modal.focus();
+        }
+
+        function releaseFocus(modal) {
+            if (modal && modal._handleKeydown) {
+                modal.removeEventListener('keydown', modal._handleKeydown);
+                delete modal._handleKeydown;
+            }
+            if (lastFocusedElement) {
+                lastFocusedElement.focus();
+                lastFocusedElement = null;
+            }
+        }
+
         function openQRModal() {
+            lastFocusedElement = document.activeElement;
             const modal = document.getElementById('qr-modal');
             const container = document.getElementById('qr-modal-code');
             if (!modal || !container) return;
@@ -4099,11 +4147,17 @@ let dataListenersSet = false;
                 correctLevel: QRCode.CorrectLevel.M
             });
             modal.classList.remove('hidden');
+            modal.setAttribute('aria-hidden', 'false');
+            trapFocus(modal, closeQRModal);
         }
 
         function closeQRModal() {
             const modal = document.getElementById('qr-modal');
-            if (modal) modal.classList.add('hidden');
+            if (modal) {
+                modal.classList.add('hidden');
+                modal.setAttribute('aria-hidden', 'true');
+                releaseFocus(modal);
+            }
         }
 
         function createCalendarEvent(data) {
@@ -4436,6 +4490,7 @@ END:VCALENDAR`;
                     existingModal.remove();
                 }
 
+                lastFocusedElement = document.activeElement;
                 const modal = this.createModal();
                 document.body.appendChild(modal);
                 const currentLang = document.documentElement.lang || 'en';
@@ -4443,11 +4498,15 @@ END:VCALENDAR`;
                 translateFragment(modal);
 
                 this.updateCustomForm();
+                trapFocus(modal, this.closeModal.bind(this));
             }
 
             createModal() {
                 const modal = document.createElement('div');
                 modal.className = 'bookmark-modal';
+                modal.setAttribute('role', 'dialog');
+                modal.setAttribute('aria-modal', 'true');
+                modal.setAttribute('tabindex', '-1');
                 modal.innerHTML = `
             <div class="bookmark-modal-content">
                 <div class="modal-header">
@@ -4764,6 +4823,7 @@ END:VCALENDAR`;
             closeModal() {
                 const modal = document.querySelector('.bookmark-modal');
                 if (modal) {
+                    releaseFocus(modal);
                     modal.remove();
                 }
             }
@@ -4936,25 +4996,31 @@ Generated: ${new Date().toLocaleString()}`;
         }
 
         function showLocationModal() {
+            lastFocusedElement = document.activeElement;
             const modal = document.getElementById('location-modal');
             if (modal) {
                 modal.classList.remove('hidden');
+                modal.setAttribute('aria-hidden', 'false');
+                trapFocus(modal, closeLocationModal);
             }
         }
 
         function confirmLocationRequest() {
-            const modal = document.getElementById('location-modal');
-            if (modal) {
-                modal.classList.add('hidden');
-            }
+            closeLocationModal();
             getLocation();
         }
 
-        function cancelLocationRequest() {
+        function closeLocationModal() {
             const modal = document.getElementById('location-modal');
             if (modal) {
                 modal.classList.add('hidden');
+                modal.setAttribute('aria-hidden', 'true');
+                releaseFocus(modal);
             }
+        }
+
+        function cancelLocationRequest() {
+            closeLocationModal();
         }
 
         function getLocation() {
@@ -5226,6 +5292,7 @@ Generated: ${new Date().toLocaleString()}`;
             const modal = document.getElementById('emergency-modal');
             const content = document.getElementById('emergency-modal-content');
             if (!modal || !content) return;
+            lastFocusedElement = document.activeElement;
 
             // Build the emergency info HTML
             let html = '';
@@ -5304,11 +5371,7 @@ Generated: ${new Date().toLocaleString()}`;
             content.innerHTML = html;
             modal.classList.remove('hidden');
             modal.setAttribute('aria-hidden', 'false');
-
-            setTimeout(() => {
-                const closeBtn = modal.querySelector('.modal-close');
-                if (closeBtn) closeBtn.focus();
-            }, 100);
+            trapFocus(modal, closeEmergencyModal);
         }
 
         function closeEmergencyModal() {
@@ -5316,6 +5379,7 @@ Generated: ${new Date().toLocaleString()}`;
             if (modal) {
                 modal.classList.add('hidden');
                 modal.setAttribute('aria-hidden', 'true');
+                releaseFocus(modal);
             }
 
             // Initialize the display view for later access


### PR DESCRIPTION
## Summary
- Add ARIA roles, focusable close buttons, and initial focus handling for QR code and location modals
- Introduce global focus trap utilities and apply them across QR, location, emergency, and bookmark manager modals
- Restore focus to the previously active element when modals close

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d1ab28448332824a23d1c23af823