### PR TITLE
Add skip links and semantic landmarks

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,6 +13,18 @@
             padding: 20px;
             line-height: 1.6;
         }
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 0;
+            background: #fff;
+            color: #000;
+            padding: 8px 16px;
+            z-index: 1000;
+        }
+        .skip-link:focus {
+            top: 0;
+        }
         .container {
             max-width: 600px;
             margin: 0 auto;
@@ -27,12 +39,13 @@
     </style>
 </head>
 <body>
-    <div class="container">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <main id="main-content" class="container">
         <h1 data-i18n="about.heading">About & Privacy</h1>
         <p data-i18n="about.storage">iKey runs entirely in your browser. Favorites and recent locations are saved in localStorage on your device.</p>
         <p data-i18n="about.offline">Once loaded, the app works offline and no data leaves your device unless you choose to share it.</p>
         <p data-i18n="about.clear">To clear your data, open your browser settings and remove site data for this page or use the "Clear browsing data" option.</p>
         <p data-i18n="about.back"><a href="index.html">Back to Home</a></p>
-    </div>
+    </main>
 </body>
 </html>

--- a/card.html
+++ b/card.html
@@ -25,6 +25,20 @@
             color: #1e293b;
         }
 
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 0;
+            background: #fff;
+            color: #000;
+            padding: 8px 16px;
+            z-index: 1000;
+        }
+
+        .skip-link:focus {
+            top: 0;
+        }
+
         *:focus-visible {
             outline: 3px solid #4f46e5;
             outline-offset: 2px;
@@ -591,15 +605,17 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="container">
-        <div class="header">
+        <header class="header">
             <h1>
                 <div class="main-logo">iK</div>
                 <span data-i18n="card.header">iKey ID Card Generator</span>
             </h1>
             <p data-i18n="card.tagline">Minimalist secure iKey Emergency ID with unique identifier</p>
-        </div>
+        </header>
 
+        <main id="main-content">
         <div class="controls">
             <div class="section-title" data-i18n="card.photoUpload">Photo Upload (Optional)</div>
             <div class="photo-section">
@@ -869,6 +885,7 @@
                 </div>
             </div>
         </div>
+        </main>
     </div>
 
     <script>

--- a/dispatch.html
+++ b/dispatch.html
@@ -27,6 +27,20 @@
             min-height: 100vh;
             padding: 10px;
         }
+
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 0;
+            background: #fff;
+            color: #000;
+            padding: 8px 16px;
+            z-index: 1000;
+        }
+
+        .skip-link:focus {
+            top: 0;
+        }
         
         .container {
             max-width: 900px;
@@ -324,8 +338,9 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="container">
-        <div class="header">
+        <header class="header">
             <div class="title" data-i18n="dispatch.header">
                 📡 Nashville Police Dispatches
                 <span class="refresh-dot"></span>
@@ -345,15 +360,17 @@
                     <div class="stat-value small" id="lastUpdate">--:--</div>
                 </div>
             </div>
-        </div>
-        
+        </header>
+
+        <main id="main-content">
         <div id="dispatchList">
                 <div class="loading">
                     <div class="loading-spinner"></div>
                     <div data-i18n="dispatch.loading">Loading dispatches...</div>
-                </div>
             </div>
         </div>
+        </main>
+    </div>
     
     <script>
         document.addEventListener('DOMContentLoaded', async () => {

--- a/faq.html
+++ b/faq.html
@@ -19,6 +19,20 @@
             padding: 20px;
         }
 
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 0;
+            background: #fff;
+            color: #000;
+            padding: 8px 16px;
+            z-index: 1000;
+        }
+
+        .skip-link:focus {
+            top: 0;
+        }
+
         .container {
             max-width: 1200px;
             margin: 0 auto;
@@ -432,12 +446,14 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="container">
-        <div class="header">
+        <header class="header">
             <h1 data-i18n="faq.header">🔐 iKey Personal Hub FAQ</h1>
             <p data-i18n="faq.description">A safe place for files and quick links. It offers an optional emergency QR.</p>
-        </div>
+        </header>
 
+        <main id="main-content">
         <div class="security-tiers">
             <div class="tier-card">
                 <div class="tier-icon">🔓</div>
@@ -479,6 +495,7 @@
             <div class="faq-container" id="faqContainer">
             <div class="no-results" data-i18n="faq.startTyping">Start typing to search or select a category above</div>
         </div>
+        </main>
     </div>
 
     <script>

--- a/home.html
+++ b/home.html
@@ -21,6 +21,19 @@
       font-family: inherit;
     }
 
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 0;
+      background: #fff;
+      color: #000;
+      padding: 8px 16px;
+      z-index: 1000;
+    }
+    .skip-link:focus {
+      top: 0;
+    }
+
     .home-container {
       display: grid;
       grid-template-columns: 1fr;
@@ -164,6 +177,8 @@
   </style>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <main id="main-content">
   <div id="card-container" class="home-container">
     <div class="loading"></div>
   </div>
@@ -171,6 +186,7 @@
   <div style="text-align:center; padding: 16px;">
     <a href="about.html" data-i18n="home.aboutLink">About &amp; Privacy</a>
   </div>
+  </main>
 
   <div id="toast" class="toast" style="display: none"></div>
 

--- a/hotlines.html
+++ b/hotlines.html
@@ -32,6 +32,18 @@
             min-height: 100vh;
             line-height: 1.6;
         }
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 0;
+            background: #fff;
+            color: #000;
+            padding: 8px 16px;
+            z-index: 1000;
+        }
+        .skip-link:focus {
+            top: 0;
+        }
         .emergency-banner {
             background: linear-gradient(90deg, #dc2626, #ef4444);
             padding: 15px;
@@ -275,10 +287,13 @@
     </style>
 </head>
 <body>
-  <div class="emergency-banner">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header class="emergency-banner">
       <a href="tel:911" data-i18n="hotlines.banner">⚠️ If you're in immediate danger, call 911 ⚠️</a>
-  </div>
+  </header>
+  <main id="main-content">
   <div class="container" id="hotlines-content"></div>
+  </main>
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
       const container = document.getElementById('hotlines-content');

--- a/index.html
+++ b/index.html
@@ -55,6 +55,20 @@
             touch-action: manipulation;
         }
 
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 0;
+            background: #fff;
+            color: #000;
+            padding: 8px 16px;
+            z-index: 1000;
+        }
+
+        .skip-link:focus {
+            top: 0;
+        }
+
         *:focus-visible {
             outline: 3px solid #4f46e5;
             outline-offset: 2px;
@@ -1903,6 +1917,7 @@
         </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <!-- Emergency Info Modal -->
     <div id="emergency-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="emergency-modal-title" tabindex="-1" aria-hidden="true">
         <div class="modal-content" style="max-width: 500px; max-height: 90vh; overflow-y: auto;">
@@ -1921,7 +1936,7 @@
         </div>
     </div>
     <!-- Header -->
-    <div class="app-header">
+    <header class="app-header">
         <div id="language-toggle">
             <button id="language-btn" aria-label="Change language">🌐</button>
             <div id="language-menu">
@@ -1935,7 +1950,7 @@
         </div>
         <h1><img src="https://storage.googleapis.com/art_homelessness/1.png" alt="iKey logo" class="logo"> iKey</h1>
         <p data-i18n="appTagline">Safe location and help hub</p>
-    </div>
+    </header>
 
     <div id="key-banner" class="key-banner hidden">
         <span id="key-banner-text"></span>
@@ -1943,8 +1958,8 @@
     </div>
 
     <!-- Tab Navigation -->
-    <div class="nav-wrapper">
-        <nav class="tab-nav" role="tablist">
+    <nav class="nav-wrapper">
+        <div class="tab-nav" role="tablist">
         <button class="tab-btn" data-tab="home" id="tab-home" role="tab" aria-controls="home" aria-selected="false" tabindex="-1" onclick="switchTab('home')" aria-label="Home" data-i18n-aria="nav.home">
             <span class="tab-icon">🏠</span>
             <span class="tab-label" data-i18n="nav.home">Home</span>
@@ -1977,7 +1992,7 @@
             <span class="tab-icon">⚙️</span>
             <span class="tab-label" data-i18n="nav.settings">Settings</span>
         </button>
-        </nav>
+        </div>
         <!-- Hidden dropdown for grouped resources -->
         <div id="resource-menu" class="dropdown-menu hidden" role="menu">
             <button onclick="switchTab('wttin')" role="menuitem" tabindex="-1">
@@ -1997,8 +2012,9 @@
                 <span>Proton</span>
             </button>
         </div>
-    </div>
+    </nav>
 
+    <main id="main-content">
     <!-- Home Tab -->
     <div id="home" class="tab-content" role="tabpanel" aria-labelledby="tab-home" tabindex="0" aria-hidden="true">
         <div class="container">
@@ -2974,6 +2990,7 @@
             </div>
         </div>
     </div>
+    </main>
 
     <script>
 

--- a/invite.html
+++ b/invite.html
@@ -42,6 +42,20 @@
             color: var(--text-dark);
         }
 
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 0;
+            background: #fff;
+            color: #000;
+            padding: 8px 16px;
+            z-index: 1000;
+        }
+
+        .skip-link:focus {
+            top: 0;
+        }
+
         *:focus-visible {
             outline: 3px solid #4f46e5;
             outline-offset: 2px;
@@ -205,12 +219,13 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="widget-container">
-        <div class="widget-header">
+        <header class="widget-header">
             <h1 data-i18n="invite.header">📅 ICS Event Generator</h1>
             <p data-i18n="invite.subtitle">Create and email calendar invites</p>
-        </div>
-        <div class="widget-body">
+        </header>
+        <main id="main-content" class="widget-body">
             <div id="instructionMessage" class="instruction-message">
                 <h4 data-i18n="invite.instructions">📧 Please complete these steps:</h4>
                 <ol>
@@ -264,7 +279,7 @@
                 <button type="button" class="btn btn-primary" onclick="generateAndEmail()" data-i18n="invite.createInviteEmail">📅 Create Invite & Email</button>
                 <button type="button" class="btn btn-secondary" onclick="resetForm()" data-i18n="invite.clearForm">Clear Form</button>
             </form>
-        </div>
+        </main>
     </div>
 
 <script>

--- a/meals.html
+++ b/meals.html
@@ -10,10 +10,15 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif; margin: 0; padding: 20px; }
         .meal-list { list-style: none; padding: 0; }
         .meal-list li { background: #f1f5f9; margin-bottom: 12px; padding: 12px; border-radius: 8px; }
+        .skip-link { position: absolute; top: -40px; left: 0; background: #fff; color: #000; padding: 8px 16px; z-index: 1000; }
+        .skip-link:focus { top: 0; }
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <main id="main-content">
     <div id="meals-content"></div>
+    </main>
     <script>
     document.addEventListener('DOMContentLoaded', async () => {
         const container = document.getElementById('meals-content');


### PR DESCRIPTION
## Summary
- add skip-to-content links across entry pages for better keyboard access
- wrap headers, navigation, and main content in semantic `<header>`, `<nav>`, and `<main>` landmarks
- style skip links to become visible on focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d1a5cba8833287b20bf090f8eb9e