### PR TITLE
Associate required form labels with inputs

### DIFF
--- a/card.html
+++ b/card.html
@@ -625,7 +625,7 @@
                 <div class="field-grid">
                     <div class="field-item required">
                         <div class="field-header">
-                            <label class="field-label required" style="margin-left: 30px;" data-i18n="card.secureEmail">Secure Email (UID)</label>
+                            <label class="field-label required" for="field_email" style="margin-left: 30px;" data-i18n="card.secureEmail">Secure Email (UID)</label>
                             <span class="char-counter" id="count_email">0/40</span>
                         </div>
                         <input type="email" class="field-input" id="field_email" maxlength="40"
@@ -634,7 +634,7 @@
 
                     <div class="field-item required">
                         <div class="field-header">
-                            <label class="field-label required" style="margin-left: 30px;" data-i18n="card.fullName">Full Name</label>
+                            <label class="field-label required" for="field_name" style="margin-left: 30px;" data-i18n="card.fullName">Full Name</label>
                             <span class="char-counter" id="count_name">0/30</span>
                         </div>
                         <input type="text" class="field-input" id="field_name" maxlength="30"
@@ -643,7 +643,7 @@
 
                     <div class="field-item required">
                         <div class="field-header">
-                            <label class="field-label required" style="margin-left: 30px;" data-i18n="card.phoneNumber">Your Phone Number</label>
+                            <label class="field-label required" for="field_phone" style="margin-left: 30px;" data-i18n="card.phoneNumber">Your Phone Number</label>
                             <span class="char-counter" id="count_phone">0/20</span>
                         </div>
                         <input type="tel" class="field-input" id="field_phone" maxlength="20"
@@ -652,7 +652,7 @@
 
                     <div class="field-item required">
                         <div class="field-header">
-                            <label class="field-label required" style="margin-left: 30px;" data-i18n="card.emergencyContact">Emergency Contact</label>
+                            <label class="field-label required" for="field_emergency" style="margin-left: 30px;" data-i18n="card.emergencyContact">Emergency Contact</label>
                             <span class="char-counter" id="count_emergency">0/20</span>
                         </div>
                         <input type="tel" class="field-input" id="field_emergency" maxlength="20"


### PR DESCRIPTION
## Summary
- Add `for` attributes to required form labels so clicking labels focuses their corresponding inputs

## Testing
- `node <<'NODE' ...` (JSDOM checks that each label is linked to its input)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d1a4b2688332a3c9bc13060b8c0a