### PR TITLE
refactor: centralize base styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The repository has no build step. Edits can be made directly to the HTML or tran
 
 When adding DOM elements at runtime (wizards, modals, etc.), call the global `translateFragment(rootElement)` helper from `scripts/translate.js`. It applies `data-i18n*` translations to the supplied subtree so new UI fragments are translated immediately.
 
+### Style guidelines
+
+- Shared styles live in `styles/base.css`. Link this stylesheet from every HTML page.
+- Avoid inline `style` attributes where possible; prefer CSS classes or page-specific style blocks.
+- Use the CSS variables in `base.css` for colors and spacing to keep a consistent look.
+
 ## Contributing
 
 ### Accessibility

--- a/about.html
+++ b/about.html
@@ -4,26 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="about.title">About & Privacy</title>
+    <link rel="stylesheet" href="styles/base.css">
     <script src="scripts/translate.js"></script>
     <style>
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            background: #f8fafc;
-            min-height: 100vh;
             padding: 20px;
-            line-height: 1.6;
-        }
-        .skip-link {
-            position: absolute;
-            top: -40px;
-            left: 0;
-            background: #fff;
-            color: #000;
-            padding: 8px 16px;
-            z-index: 1000;
-        }
-        .skip-link:focus {
-            top: 0;
         }
         .container {
             max-width: 600px;
@@ -35,7 +20,7 @@
         }
         h1 { font-size: 1.8rem; margin-bottom: 16px; }
         p { margin-bottom: 12px; }
-        a { color: var(--primary, #3b82f6); }
+        a { color: var(--primary); }
     </style>
 </head>
 <body>

--- a/card.html
+++ b/card.html
@@ -6,42 +6,14 @@
     <title data-i18n="card.title">iKey ID Card Generator</title>
     <link rel="icon" href="https://storage.googleapis.com/art_homelessness/favicon-32x32.png" type="image/png">
     <link rel="apple-touch-icon" href="https://storage.googleapis.com/art_homelessness/favicon-32x32.png">
+    <link rel="stylesheet" href="styles/base.css">
     <script src="scripts/qrcode.min.js"></script>
     <script src="scripts/lz-string.min.js"></script>
     <script src="scripts/html2canvas.min.js"></script>
     <script src="scripts/translate.js"></script>
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #f8fafc;
-            min-height: 100vh;
             padding: 20px;
-            color: #1e293b;
-        }
-
-        .skip-link {
-            position: absolute;
-            top: -40px;
-            left: 0;
-            background: #fff;
-            color: #000;
-            padding: 8px 16px;
-            z-index: 1000;
-        }
-
-        .skip-link:focus {
-            top: 0;
-        }
-
-        *:focus-visible {
-            outline: 3px solid #4f46e5;
-            outline-offset: 2px;
         }
 
         .container {

--- a/dispatch.html
+++ b/dispatch.html
@@ -4,44 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="dispatch.title">Nashville Police Active Dispatches</title>
+    <link rel="stylesheet" href="styles/base.css">
     <script src="scripts/resources.js"></script>
     <script src="scripts/translate.js"></script>
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        :root {
-            --base-font-size: 16px;
-        }
-
-        html {
-            font-size: var(--base-font-size);
-        }
-
-        
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
             background: #f7fafc;
-            min-height: 100vh;
             padding: 10px;
         }
 
-        .skip-link {
-            position: absolute;
-            top: -40px;
-            left: 0;
-            background: #fff;
-            color: #000;
-            padding: 8px 16px;
-            z-index: 1000;
-        }
-
-        .skip-link:focus {
-            top: 0;
-        }
-        
         .container {
             max-width: 900px;
             margin: 0 auto;

--- a/faq.html
+++ b/faq.html
@@ -4,33 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="faq.title">iKey Personal Hub - FAQ</title>
+    <link rel="stylesheet" href="styles/base.css">
     <script src="scripts/translate.js"></script>
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            background: #f8fafc;
-            min-height: 100vh;
             padding: 20px;
-        }
-
-        .skip-link {
-            position: absolute;
-            top: -40px;
-            left: 0;
-            background: #fff;
-            color: #000;
-            padding: 8px 16px;
-            z-index: 1000;
-        }
-
-        .skip-link:focus {
-            top: 0;
         }
 
         .container {

--- a/home.html
+++ b/home.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title data-i18n="homeTitle">iKey Home</title>
+  <link rel="stylesheet" href="styles/base.css">
   <script src="scripts/translate.js"></script>
   <style>
     :root {
@@ -13,25 +14,6 @@
       --emergency-color: #f87171;
       --secondary: #666;
       --primary: var(--live-color);
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-    }
-
-    body {
-      margin: 0;
-      font-family: inherit;
-    }
-
-    .skip-link {
-      position: absolute;
-      top: -40px;
-      left: 0;
-      background: #fff;
-      color: #000;
-      padding: 8px 16px;
-      z-index: 1000;
-    }
-    .skip-link:focus {
-      top: 0;
     }
 
     .home-container {

--- a/hotlines.html
+++ b/hotlines.html
@@ -4,14 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="hotlines.title">Emergency Support Hotlines - Verified 2025</title>
+    <link rel="stylesheet" href="styles/base.css">
     <script src="scripts/translate.js"></script>
     <script src="scripts/resources.js"></script>
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
         :root {
             --primary: #2563eb;
             --primary-dark: #1e40af;
@@ -26,23 +22,8 @@
             --gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         }
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
             background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
             color: var(--text-primary);
-            min-height: 100vh;
-            line-height: 1.6;
-        }
-        .skip-link {
-            position: absolute;
-            top: -40px;
-            left: 0;
-            background: #fff;
-            color: #000;
-            padding: 8px 16px;
-            z-index: 1000;
-        }
-        .skip-link:focus {
-            top: 0;
         }
         .emergency-banner {
             background: linear-gradient(90deg, #dc2626, #ef4444);

--- a/icsdownload.html
+++ b/icsdownload.html
@@ -4,20 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Email Calendar Invite Generator</title>
+    <link rel="stylesheet" href="styles/base.css">
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
             padding: 20px;
         }
-        
+
         .container {
             max-width: 600px;
             margin: 0 auto;

--- a/index.html
+++ b/index.html
@@ -13,67 +13,9 @@
     <!-- External Libraries -->
     <script src="scripts/qrcode.min.js"></script>
     <script src="scripts/lz-string.min.js"></script>
-    
+    <link rel="stylesheet" href="styles/base.css">
+
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-            -webkit-tap-highlight-color: transparent;
-        }
-
-        :root {
-            --primary: #4f46e5;
-            --primary-dark: #4338ca;
-            --proton: #6d4aff;
-            --secondary: #374151;
-            --secondary-light: #6b7280;
-            --success: #0f5132;
-            --danger: #7f1d1d;
-            --warning: #92400e;
-            --light: #f8fafc;
-            --dark: #1e293b;
-            --border: #e2e8f0;
-            --radius: 16px;
-            --shadow-sm: 0 1px 3px rgba(0,0,0,0.1);
-            --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
-            --shadow-lg: 0 10px 25px rgba(0,0,0,0.1);
-            --base-font-size: 16px;
-            --touch-padding: 0.75rem 1rem;
-        }
-        html {
-            font-size: var(--base-font-size);
-        }
-
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            background: #f8fafc;
-            min-height: 100vh;
-            color: var(--dark);
-            line-height: 1.6;
-            touch-action: manipulation;
-        }
-
-        .skip-link {
-            position: absolute;
-            top: -40px;
-            left: 0;
-            background: #fff;
-            color: #000;
-            padding: 8px 16px;
-            z-index: 1000;
-        }
-
-        .skip-link:focus {
-            top: 0;
-        }
-
-        *:focus-visible {
-            outline: 3px solid #4f46e5;
-            outline-offset: 2px;
-        }
-
         /* Header */
         .app-header {
             background: #ffffff;

--- a/invite.html
+++ b/invite.html
@@ -4,14 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="invite.title">ICS Event Generator - Proton Calendar Compatible</title>
+    <link rel="stylesheet" href="styles/base.css">
     <script src="scripts/translate.js"></script>
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
         :root {
             --proton-purple: #6d4aff;
             --proton-purple-dark: #5a3dd1;
@@ -24,41 +19,14 @@
             --warning: #f59e0b;
             --danger: #ef4444;
             --radius: 12px;
-            --base-font-size: 16px;
         }
-        html {
-            font-size: var(--base-font-size);
-        }
-
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: #f8fafc;
-            min-height: 100vh;
             display: flex;
             align-items: center;
             justify-content: center;
             padding: 20px;
             color: var(--text-dark);
-        }
-
-        .skip-link {
-            position: absolute;
-            top: -40px;
-            left: 0;
-            background: #fff;
-            color: #000;
-            padding: 8px 16px;
-            z-index: 1000;
-        }
-
-        .skip-link:focus {
-            top: 0;
-        }
-
-        *:focus-visible {
-            outline: 3px solid #4f46e5;
-            outline-offset: 2px;
         }
 
         .widget-container {

--- a/meals.html
+++ b/meals.html
@@ -4,14 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="meals.title">Free Meal Resources</title>
+    <link rel="stylesheet" href="styles/base.css">
     <script src="scripts/translate.js"></script>
     <script src="scripts/resources.js"></script>
     <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif; margin: 0; padding: 20px; }
+        body { padding: 20px; }
         .meal-list { list-style: none; padding: 0; }
         .meal-list li { background: #f1f5f9; margin-bottom: 12px; padding: 12px; border-radius: 8px; }
-        .skip-link { position: absolute; top: -40px; left: 0; background: #fff; color: #000; padding: 8px 16px; z-index: 1000; }
-        .skip-link:focus { top: 0; }
     </style>
 </head>
 <body>

--- a/styles/base.css
+++ b/styles/base.css
@@ -1,0 +1,58 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+:root {
+    --primary: #4f46e5;
+    --primary-dark: #4338ca;
+    --proton: #6d4aff;
+    --secondary: #374151;
+    --secondary-light: #6b7280;
+    --success: #0f5132;
+    --danger: #7f1d1d;
+    --warning: #92400e;
+    --light: #f8fafc;
+    --dark: #1e293b;
+    --border: #e2e8f0;
+    --radius: 16px;
+    --shadow-sm: 0 1px 3px rgba(0,0,0,0.1);
+    --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
+    --shadow-lg: 0 10px 25px rgba(0,0,0,0.1);
+    --base-font-size: 16px;
+    --touch-padding: 0.75rem 1rem;
+}
+
+html {
+    font-size: var(--base-font-size);
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background: #f8fafc;
+    min-height: 100vh;
+    color: var(--dark);
+    line-height: 1.6;
+    touch-action: manipulation;
+}
+
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: #fff;
+    color: #000;
+    padding: 8px 16px;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
+*:focus-visible {
+    outline: 3px solid #4f46e5;
+    outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- Move shared CSS variables and base styles into `styles/base.css`
- Link the new stylesheet from all HTML pages and trim redundant inline styles
- Document CSS style guidelines in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d8705f588332af402e29c1bf7a8e