### PR TITLE
Add global responsive CSS to prevent overflow on small screens

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title data-i18n="about.title">About & Privacy</title>
     <script src="scripts/translate.js"></script>
     <style>

--- a/card.html
+++ b/card.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title data-i18n="card.title">iKey ID Card Generator</title>
     <link rel="icon" href="https://storage.googleapis.com/art_homelessness/favicon-32x32.png" type="image/png">
     <link rel="apple-touch-icon" href="https://storage.googleapis.com/art_homelessness/favicon-32x32.png">

--- a/dispatch.html
+++ b/dispatch.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title data-i18n="dispatch.title">Nashville Police Active Dispatches</title>
     <script src="scripts/resources.js"></script>
     <script src="scripts/translate.js"></script>

--- a/faq.html
+++ b/faq.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title data-i18n="faq.title">iKey Personal Hub - FAQ</title>
     <script src="scripts/translate.js"></script>
     <style>

--- a/home.html
+++ b/home.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="styles.css">
   <title data-i18n="homeTitle">iKey Home</title>
   <script src="scripts/translate.js"></script>
   <style>

--- a/hotlines.html
+++ b/hotlines.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title data-i18n="hotlines.title">Emergency Support Hotlines - Verified 2025</title>
     <script src="scripts/translate.js"></script>
     <script src="scripts/resources.js"></script>

--- a/icsdownload.html
+++ b/icsdownload.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title>Email Calendar Invite Generator</title>
     <style>
         * {

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <meta name="description" content="iKey - Safe location hub with quick emergency access">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/invite.html
+++ b/invite.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title data-i18n="invite.title">ICS Event Generator - Proton Calendar Compatible</title>
     <script src="scripts/translate.js"></script>
     <style>

--- a/meals.html
+++ b/meals.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title data-i18n="meals.title">Free Meal Resources</title>
     <script src="scripts/translate.js"></script>
     <script src="scripts/resources.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,27 @@
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+html, body {
+    max-width: 100%;
+    overflow-x: hidden;
+}
+
+body {
+    font-size: 18px;
+    word-wrap: break-word;
+}
+
+img, video, canvas, svg {
+    max-width: 100%;
+    height: auto;
+}
+
+@media (max-width: 480px) {
+    body {
+        font-size: 16px;
+    }
+    [style*="display: flex"] {
+        flex-wrap: wrap;
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared `styles.css` to manage responsive layout, wrap flex containers, and ensure images scale.
- Link all HTML pages to the new stylesheet for consistent overflow handling.

## Testing
- `node test-responsive.js`

------
https://chatgpt.com/codex/tasks/task_b_68c5d86f1c408332a4ea7e328fea0b7e