### PR TITLE
Add training resources and translations

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -446,7 +446,21 @@
             "meals": "Meals Resources",
             "policeDispatch": "Nashville Police Dispatch",
             "crisisLine": "Suicide & Crisis Lifeline: 988",
-            "poisonControlNumber": "Poison Control: 1-800-222-1222"
+            "poisonControlNumber": "Poison Control: 1-800-222-1222",
+            "training": "Training Materials"
+        },
+        "training": {
+            "title": "Training Guide",
+            "intro": "Follow these steps to get started.",
+            "steps": {
+                "step1": "Open the iKey app.",
+                "step2": "Tap Save to record your location.",
+                "step3": "Share with trusted contacts."
+            },
+            "back": "Back to Home"
+        },
+        "about": {
+            "trainingLink": "View training materials"
         },
         "card": {
             "title": "iKey ID Card Generator",
@@ -915,7 +929,21 @@
             "meals": "Recursos de Comidas",
             "policeDispatch": "Despacho Policial de Nashville",
             "crisisLine": "Línea de Suicidio y Crisis: 988",
-            "poisonControlNumber": "Control de Venenos: 1-800-222-1222"
+            "poisonControlNumber": "Control de Venenos: 1-800-222-1222",
+            "training": "Materiales de capacitación"
+        },
+        "training": {
+            "title": "Guía de capacitación",
+            "intro": "Sigue estos pasos para comenzar.",
+            "steps": {
+                "step1": "Abre la aplicación iKey.",
+                "step2": "Pulsa Guardar para registrar tu ubicación.",
+                "step3": "Compártelo con contactos de confianza."
+            },
+            "back": "Volver al inicio"
+        },
+        "about": {
+            "trainingLink": "Ver materiales de capacitación"
         },
         "card": {
             "title": "Generador de Tarjeta de ID de iKey",
@@ -1374,7 +1402,21 @@
             "meals": "موارد الوجبات",
             "policeDispatch": "إرسال شرطة ناشفيل",
             "crisisLine": "خط الأزمات والانتحار: 988",
-            "poisonControlNumber": "مراقبة السموم: 1-800-222-1222"
+            "poisonControlNumber": "مراقبة السموم: 1-800-222-1222",
+            "training": "مواد التدريب"
+        },
+        "training": {
+            "title": "دليل التدريب",
+            "intro": "اتبع هذه الخطوات للبدء.",
+            "steps": {
+                "step1": "افتح تطبيق iKey.",
+                "step2": "اضغط حفظ لتسجيل موقعك.",
+                "step3": "شارك مع جهات الاتصال الموثوقة."
+            },
+            "back": "العودة إلى الصفحة الرئيسية"
+        },
+        "about": {
+            "trainingLink": "عرض مواد التدريب"
         },
         "card": {
             "title": "مولد بطاقة هوية iKey",
@@ -1827,7 +1869,21 @@
             "meals": "Çavkaniyên Xwarinan",
             "policeDispatch": "Şandina Polîsê Nashville",
             "crisisLine": "Xeta Xwekujtin û Krîzê: 988",
-            "poisonControlNumber": "Kontrola Jehrê: 1-800-222-1222"
+            "poisonControlNumber": "Kontrola Jehrê: 1-800-222-1222",
+            "training": "Materyalên Fêrbûnê"
+        },
+        "training": {
+            "title": "Rêbernameya Fêrbûnê",
+            "intro": "Ji bo destpêkê van gavên bişopînin.",
+            "steps": {
+                "step1": "Sepana iKey veke.",
+                "step2": "Li ser Save bitikîne da ku cîhê xwe tomar bike.",
+                "step3": "Bi têkilîyên ewle parve bike."
+            },
+            "back": "Vegere Serûpelê"
+        },
+        "about": {
+            "trainingLink": "Materyalên fêrbûnê bibîne"
         },
         "misc": {
             "apps": "Proton Apps",
@@ -2179,7 +2235,21 @@
             "meals": "Ilaha Cuntada",
             "policeDispatch": "Dirista Booliska Nashville",
             "crisisLine": "Khadka Ismiidaaminta & Dhibaatada: 988",
-            "poisonControlNumber": "Xakamaynta Sunta: 1-800-222-1222"
+            "poisonControlNumber": "Xakamaynta Sunta: 1-800-222-1222",
+            "training": "Qalabka tababarka"
+        },
+        "training": {
+            "title": "Hagaha tababarka",
+            "intro": "Raac tillaabooyinkan si aad u bilowdo.",
+            "steps": {
+                "step1": "Fur app-ka iKey.",
+                "step2": "Taabo Kaydi si aad u qorto goobtaada.",
+                "step3": "La wadaag dadka aad ku kalsoon tahay."
+            },
+            "back": "Ku noqo bogga hore"
+        },
+        "about": {
+            "trainingLink": "Eeg qalabka tababarka"
         },
         "misc": {
             "apps": "Proton Apps",
@@ -2531,7 +2601,21 @@
             "meals": "餐食资源",
             "policeDispatch": "纳什维尔警察调度",
             "crisisLine": "自杀与危机生命线：988",
-            "poisonControlNumber": "中毒控制：1-800-222-1222"
+            "poisonControlNumber": "中毒控制：1-800-222-1222",
+            "training": "培训资料"
+        },
+        "training": {
+            "title": "培训指南",
+            "intro": "按照以下步骤开始使用。",
+            "steps": {
+                "step1": "打开 iKey 应用。",
+                "step2": "点击“保存”记录你的位置。",
+                "step3": "与可信联系人分享。"
+            },
+            "back": "返回主页"
+        },
+        "about": {
+            "trainingLink": "查看培训资料"
         },
         "misc": {
             "apps": "Proton Apps",

--- a/about.html
+++ b/about.html
@@ -45,6 +45,7 @@
         <p data-i18n="about.storage">iKey runs entirely in your browser. Favorites and recent locations are saved in localStorage on your device.</p>
         <p data-i18n="about.offline">Once loaded, the app works offline and no data leaves your device unless you choose to share it.</p>
         <p data-i18n="about.clear">To clear your data, open your browser settings and remove site data for this page or use the "Clear browsing data" option.</p>
+        <p data-i18n="about.trainingLink"><a href="resources/training/index.html">Training Materials</a></p>
         <p data-i18n="about.back"><a href="index.html">Back to Home</a></p>
     </main>
 </body>

--- a/resources/training/index.html
+++ b/resources/training/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title data-i18n="training.title">Training Guide</title>
+    <script src="../../scripts/translate.js"></script>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: #f8fafc;
+            min-height: 100vh;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background: #fff;
+            padding: 20px;
+            border-radius: 16px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        ol {
+            margin-left: 20px;
+        }
+    </style>
+</head>
+<body>
+    <main class="container">
+        <h1 data-i18n="training.title">Training Guide</h1>
+        <p data-i18n="training.intro">Follow these steps to get started.</p>
+        <ol>
+            <li data-i18n="training.steps.step1">Open the iKey app.</li>
+            <li data-i18n="training.steps.step2">Tap Save to record your location.</li>
+            <li data-i18n="training.steps.step3">Share with trusted contacts.</li>
+        </ol>
+        <p><a href="../../index.html" data-i18n="training.back">Back to Home</a></p>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add new training guide under `resources/training` with internationalized step-by-step instructions
- Link training materials from the About page for easy access
- Extend translation terms with entries for training content and link descriptions in multiple languages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d86a57208332966eeb84ec23e8be