### PR TITLE
feat: show scanned key banner and quick action active states

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -4,6 +4,10 @@
         "appLogo": "🔐 iKey",
         "appTagline": "Secure Location & Personal Safety Hub",
         "homeTitle": "iKey Home",
+        "keyBanner": {
+            "viewingScanned": "Viewing Scanned Key",
+            "return": "Return to My Key"
+        },
         "nav": {
             "home": "Home",
             "iKey": "iKey",
@@ -144,10 +148,15 @@
             "emailAddress": "Email Address",
             "quick": {
                 "call911": "911",
+                "call911Active": "911 (Added)",
                 "text911": "Text 911",
+                "text911Active": "Text 911 (Added)",
                 "call988": "Crisis",
+                "call988Active": "Crisis (Added)",
                 "callPoison": "Poison",
-                "textQuick": "Text"
+                "callPoisonActive": "Poison (Added)",
+                "textQuick": "Text",
+                "textQuickActive": "Text (Added)"
             },
             "pages": {
                 "ikey": "Medical",
@@ -572,6 +581,10 @@
         "appLogo": "🔐 iKey",
         "appTagline": "Centro de Ubicación Segura y Seguridad Personal",
         "homeTitle": "iKey Inicio",
+        "keyBanner": {
+            "viewingScanned": "Viendo llave escaneada",
+            "return": "Volver a mi llave"
+        },
         "nav": {
             "home": "Inicio",
             "iKey": "iKey",
@@ -712,10 +725,15 @@
             "emailAddress": "Dirección de correo",
             "quick": {
                 "call911": "911",
+                "call911Active": "911 (Activo)",
                 "text911": "Texto 911",
+                "text911Active": "Texto 911 (Activo)",
                 "call988": "Crisis",
+                "call988Active": "Crisis (Activo)",
                 "callPoison": "Veneno",
-                "textQuick": "Texto"
+                "callPoisonActive": "Veneno (Activo)",
+                "textQuick": "Texto",
+                "textQuickActive": "Texto (Activo)"
             },
             "pages": {
                 "ikey": "Médico",
@@ -1031,6 +1049,10 @@
         "appLogo": "🔐 iKey",
         "appTagline": "مركز الموقع الآمن والسلامة الشخصية",
         "homeTitle": "iKey الرئيسية",
+        "keyBanner": {
+            "viewingScanned": "عرض المفتاح الممسوح",
+            "return": "العودة إلى مفتاحي"
+        },
         "nav": {
             "home": "الرئيسية",
             "iKey": "iKey",
@@ -1171,10 +1193,15 @@
             "emailAddress": "عنوان البريد",
             "quick": {
                 "call911": "911",
+                "call911Active": "911 (مفعل)",
                 "text911": "نص 911",
+                "text911Active": "نص 911 (مفعل)",
                 "call988": "أزمة",
+                "call988Active": "أزمة (مفعل)",
                 "callPoison": "سموم",
-                "textQuick": "نص"
+                "callPoisonActive": "سموم (مفعل)",
+                "textQuick": "نص",
+                "textQuickActive": "نص (مفعل)"
             },
             "pages": {
                 "ikey": "طبي",
@@ -1490,6 +1517,10 @@
         "appLogo": "🔐 iKey",
         "appTagline": "Navenda Cihê Ewledar û Ewlehiya Kesane",
         "homeTitle": "iKey Mal",
+        "keyBanner": {
+            "viewingScanned": "Mifteya scanî tê dîtin",
+            "return": "Vegere Mifteya min"
+        },
         "nav": {
             "home": "Mal",
             "iKey": "iKey",
@@ -1630,10 +1661,15 @@
             "emailAddress": "Email Address",
             "quick": {
                 "call911": "911",
+                "call911Active": "911 (Çalak)",
                 "text911": "Text 911",
+                "text911Active": "Text 911 (Çalak)",
                 "call988": "Crisis",
+                "call988Active": "Crisis (Çalak)",
                 "callPoison": "Poison",
-                "textQuick": "Text"
+                "callPoisonActive": "Poison (Çalak)",
+                "textQuick": "Text",
+                "textQuickActive": "Text (Çalak)"
             },
             "pages": {
                 "ikey": "Medical",
@@ -1842,6 +1878,10 @@
         "appLogo": "🔐 iKey",
         "appTagline": "Xarunta Goobta Ammaan iyo Badbaadada Shakhsi",
         "homeTitle": "iKey Guri",
+        "keyBanner": {
+            "viewingScanned": "Daawashada Furaha la Sawiray",
+            "return": "Ku noqo Furahayga"
+        },
         "nav": {
             "home": "Guri",
             "iKey": "iKey",
@@ -1982,10 +2022,15 @@
             "emailAddress": "Cinwaanka iimaylka",
             "quick": {
                 "call911": "911",
+                "call911Active": "911 (Firfircoon)",
                 "text911": "Qoraal 911",
+                "text911Active": "Qoraal 911 (Firfircoon)",
                 "call988": "Krisis",
+                "call988Active": "Krisis (Firfircoon)",
                 "callPoison": "Sun",
-                "textQuick": "Qoraal"
+                "callPoisonActive": "Sun (Firfircoon)",
+                "textQuick": "Qoraal",
+                "textQuickActive": "Qoraal (Firfircoon)"
             },
             "pages": {
                 "ikey": "Caafimaad",
@@ -2194,6 +2239,10 @@
         "appLogo": "🔐 iKey",
         "appTagline": "安全位置与个人安全中心",
         "homeTitle": "iKey 主页",
+        "keyBanner": {
+            "viewingScanned": "查看扫描的密钥",
+            "return": "返回到我的密钥"
+        },
         "nav": {
             "home": "主页",
             "iKey": "iKey",
@@ -2334,10 +2383,15 @@
             "emailAddress": "邮箱地址",
             "quick": {
                 "call911": "911",
+                "call911Active": "911（已添加）",
                 "text911": "短信 911",
+                "text911Active": "短信 911（已添加）",
                 "call988": "危机",
+                "call988Active": "危机（已添加）",
                 "callPoison": "中毒",
-                "textQuick": "短信"
+                "callPoisonActive": "中毒（已添加）",
+                "textQuick": "短信",
+                "textQuickActive": "短信（已添加）"
             },
             "pages": {
                 "ikey": "医疗",

--- a/index.html
+++ b/index.html
@@ -1959,8 +1959,8 @@
     </header>
 
     <div id="key-banner" class="key-banner hidden">
-        <span id="key-banner-text"></span>
-        <button id="back-to-my-key" class="btn btn-secondary hidden" onclick="returnToMyKey()">Back to my key</button>
+        <span id="key-banner-text" data-i18n="keyBanner.viewingScanned"></span>
+        <button id="back-to-my-key" class="btn btn-secondary hidden" onclick="returnToMyKey()" data-i18n="keyBanner.return">Return to My Key</button>
     </div>
 
     <!-- Tab Navigation -->
@@ -4222,6 +4222,13 @@ END:VCALENDAR`;
                 this.longPressTimer = null;
                 this.draggedElement = null;
                 this.touchStartTime = null;
+                this.quickActions = {
+                    'call-911': { optionName: '911', name: 'Emergency', url: 'tel:911', icon: '🚨', key: 'wizard.quick.call911', activeKey: 'wizard.quick.call911Active' },
+                    'text-911': { optionName: 'Text 911', name: 'Text 911', url: 'sms:', icon: '✉️', key: 'wizard.quick.text911', activeKey: 'wizard.quick.text911Active' },
+                    'call-988': { optionName: 'Crisis', name: 'Crisis Line', url: 'tel:988', icon: '💬', key: 'wizard.quick.call988', activeKey: 'wizard.quick.call988Active' },
+                    'call-poison': { optionName: 'Poison', name: 'Poison Control', url: 'tel:+18002221222', icon: '☠️', key: 'wizard.quick.callPoison', activeKey: 'wizard.quick.callPoisonActive' },
+                    'text-quick': { optionName: 'Text', name: 'Quick Text', url: 'sms:', icon: '💬', key: 'wizard.quick.textQuick', activeKey: 'wizard.quick.textQuickActive' }
+                };
 
                 this.protonApps = {
                     mail: { 
@@ -4624,22 +4631,20 @@ END:VCALENDAR`;
             }
 
             getQuickActionsHTML() {
-                const actions = [
-                    { type: 'call-911', key: 'wizard.quick.call911', name: '911', icon: '🚨' },
-                    { type: 'text-911', key: 'wizard.quick.text911', name: 'Text 911', icon: '✉️' },
-                    { type: 'call-988', key: 'wizard.quick.call988', name: 'Crisis', icon: '💬' },
-                    { type: 'call-poison', key: 'wizard.quick.callPoison', name: 'Poison', icon: '☠️' },
-                    { type: 'text-quick', key: 'wizard.quick.textQuick', name: 'Text', icon: '💬' }
-                ];
-
-                return actions.map(action => `
-            <div class="bookmark-option" onclick="bookmarkManager.addQuickAction('${action.type}')">
+                return Object.entries(this.quickActions).map(([type, action]) => {
+                    const isActive = this.bookmarks.some(b => b.type === 'action' && b.url === action.url);
+                    const labelKey = isActive ? action.activeKey : action.key;
+                    const label = t(labelKey, isActive ? `${action.optionName} (Added)` : action.optionName);
+                    const handler = isActive ? `bookmarkManager.removeQuickAction('${type}')` : `bookmarkManager.addQuickAction('${type}')`;
+                    return `
+            <div class="bookmark-option${isActive ? ' active' : ''}" onclick="${handler}">
                 <div class="option-icon">
                     <span class="option-emoji">${action.icon}</span>
                 </div>
-                <div class="option-label" data-i18n="${action.key}">${action.name}</div>
+                <div class="option-label" data-i18n="${labelKey}">${label}</div>
             </div>
-        `).join('');
+        `;
+                }).join('');
             }
 
             getInternalPagesHTML() {
@@ -4733,23 +4738,25 @@ END:VCALENDAR`;
             }
 
             addQuickAction(actionType) {
-                const actions = {
-                    'call-911': { name: 'Emergency', url: 'tel:911', icon: '🚨' },
-                    'text-911': { name: 'Text 911', url: 'sms:', icon: '💬' },
-                    'call-988': { name: 'Crisis Line', url: 'tel:988', icon: '💬' },
-                    'call-poison': { name: 'Poison Control', url: 'tel:+18002221222', icon: '☠️' },
-                    'text-quick': { name: 'Quick Text', url: 'sms:', icon: '💬' }
-                };
-
-                const action = actions[actionType];
-                if (action) {
+                const action = this.quickActions[actionType];
+                if (action && !this.bookmarks.some(b => b.type === 'action' && b.url === action.url)) {
                     this.bookmarks.push({
                         type: 'action',
-                        ...action
+                        name: action.name,
+                        url: action.url,
+                        icon: action.icon
                     });
                     this.save();
                     this.closeModal();
                 }
+            }
+
+            removeQuickAction(actionType) {
+                const action = this.quickActions[actionType];
+                if (!action) return;
+                this.bookmarks = this.bookmarks.filter(b => !(b.type === 'action' && b.url === action.url));
+                this.save();
+                this.closeModal();
             }
 
             addInternalPage(pageId) {
@@ -5341,6 +5348,7 @@ Generated: ${new Date().toLocaleString()}`;
 
         let displayData = null;
         let isOwnKey = false;
+        let viewingScannedKey = false;
 
         function showEmergencyModal(data) {
             const modal = document.getElementById('emergency-modal');
@@ -5701,20 +5709,14 @@ Generated: ${new Date().toLocaleString()}`;
             const textEl = document.getElementById('key-banner-text');
             const backBtn = document.getElementById('back-to-my-key');
             if (!banner || !textEl) return;
-            if (!displayData) {
+            if (!viewingScannedKey) {
                 banner.classList.add('hidden');
                 return;
             }
-            const myEmail = localStorage.getItem('myKeyEmail');
+            textEl.textContent = t('keyBanner.viewingScanned', 'Viewing Scanned Key');
             const myHash = localStorage.getItem('myKeyData');
-            isOwnKey = myEmail && displayData.pe && displayData.pe === myEmail;
-            textEl.textContent = isOwnKey ? 'Viewing your own key' : "Viewing someone else's key - read only";
-            if (isOwnKey) {
-                backBtn.classList.add('hidden');
-            } else {
-                if (myHash) backBtn.classList.remove('hidden');
-                else backBtn.classList.add('hidden');
-            }
+            if (myHash) backBtn.classList.remove('hidden');
+            else backBtn.classList.add('hidden');
             banner.classList.remove('hidden');
             if (bookmarkManager) bookmarkManager.render();
         }
@@ -6168,24 +6170,27 @@ Generated: ${new Date().toLocaleString()}`;
 
             // Check for existing QR data in URL
             const hash = decodeURIComponent(window.location.hash.slice(1));
+            const myHash = localStorage.getItem('myKeyData');
+            viewingScannedKey = !!hash && hash !== myHash;
             if (hash) {
                 try {
                     const decompressed = decompressData(hash);
-                    const data = JSON.parse(decompressed);
+                    const tempData = JSON.parse(decompressed);
                     // `pe` was introduced in schema v2; older QR codes may omit it
-                    if (data.p && !data.ph) {
-                        data.ph = data.p;
+                    if (tempData.p && !tempData.ph) {
+                        tempData.ph = tempData.p;
                     }
 
-                    displayData = data;
-                    updateKeyBanner();
+                    displayData = tempData;
+                    const myEmail = localStorage.getItem('myKeyEmail');
+                    isOwnKey = myEmail && tempData.pe && tempData.pe === myEmail;
 
                     const scanKey = `scanned_${hash}`;
                     if (!localStorage.getItem(scanKey)) {
                         localStorage.setItem(scanKey, '1');
-                        showEmergencyModal(data);
+                        showEmergencyModal(tempData);
                     } else {
-                        initializeDisplayView(data);
+                        initializeDisplayView(tempData);
                     }
 
                     // Switch to home tab (modal will be on top)


### PR DESCRIPTION
## Summary
- highlight when viewing a scanned key and offer quick return to the user's key
- treat scanned data as temporary and avoid saving it to localStorage
- show active quick actions in the bookmark modal and add translations for new labels

## Testing
- `python -m py_compile scripts/generate_translation_doc.py`
- `python -m json.tool TRANSLATION_TERMS.md > /tmp/translation.json`


------
https://chatgpt.com/codex/tasks/task_b_68c5d85fdefc83329cdb9030f2a7e601