### PR TITLE
Limit maximum text size to AAA

### DIFF
--- a/dispatch.html
+++ b/dispatch.html
@@ -420,7 +420,7 @@
                 fontSize = "20px";
                 zoom = "1.35";
                 break;
-            case "AAAA":
+            case "AAA":
                 fontSize = "24px";
                 zoom = "1.5";
                 break;

--- a/index.html
+++ b/index.html
@@ -2889,7 +2889,7 @@
                             <option value="aaa">aaa</option>
                             <option value="aaA">aaA</option>
                             <option value="aAA">aAA</option>
-                            <option value="AAAA">AAAA</option>
+                            <option value="AAA">AAA</option>
                         </select>
                     </div>
                 </div>
@@ -6236,7 +6236,7 @@ Generated: ${new Date().toLocaleString()}`;
                     fontSize = "20px";
                     zoom = "1.35";
                     break;
-                case "AAAA":
+                case "AAA":
                     fontSize = "24px";
                     zoom = "1.5";
                     break;

--- a/invite.html
+++ b/invite.html
@@ -415,7 +415,7 @@
                 fontSize = "20px";
                 zoom = "1.35";
                 break;
-            case "AAAA":
+            case "AAA":
                 fontSize = "24px";
                 zoom = "1.5";
                 break;


### PR DESCRIPTION
## Summary
- cap text size at AAA instead of AAAA in settings and scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5dbbe41588332966a37480261f3b9