### PR TITLE
Handle scanned QR code modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5340,6 +5340,7 @@ Generated: ${new Date().toLocaleString()}`;
         }
 
         let displayData = null;
+        let scannedKeyData = null;
         let isOwnKey = false;
 
         function showEmergencyModal(data) {
@@ -5705,10 +5706,8 @@ Generated: ${new Date().toLocaleString()}`;
                 banner.classList.add('hidden');
                 return;
             }
-            const myEmail = localStorage.getItem('myKeyEmail');
             const myHash = localStorage.getItem('myKeyData');
-            isOwnKey = myEmail && displayData.pe && displayData.pe === myEmail;
-            textEl.textContent = isOwnKey ? 'Viewing your own key' : "Viewing someone else's key - read only";
+            textEl.textContent = isOwnKey ? 'My iKey' : 'Scanned Card';
             if (isOwnKey) {
                 backBtn.classList.add('hidden');
             } else {
@@ -6177,6 +6176,10 @@ Generated: ${new Date().toLocaleString()}`;
                         data.ph = data.p;
                     }
 
+                    scannedKeyData = data;
+                    const myEmail = localStorage.getItem('myKeyEmail');
+                    const scannedEmail = data.pe;
+                    isOwnKey = myEmail && scannedEmail && scannedEmail === myEmail;
                     displayData = data;
                     updateKeyBanner();
 


### PR DESCRIPTION
## Summary
- Decode scanned QR code payload and extract email
- Flag scans from the user's own email as "My iKey" and others as "Scanned Card"
- Store scanned data in a temporary object to avoid overwriting local key

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5dbca44288332a76856b146f9dda4