### PR TITLE
Replace tooltip glyph with custom question mark icon

### DIFF
--- a/card.html
+++ b/card.html
@@ -604,11 +604,13 @@
         /* Tooltip icon */
         .info-icon {
             display: inline-block;
+            width: 1em;
+            height: 1em;
             margin-left: 4px;
-            color: #4f46e5;
+            background: url('https://storage.googleapis.com/art_homelessness/tool%20tip%20question%20mark.png') no-repeat center/contain;
             cursor: pointer;
             position: relative;
-            font-weight: 600;
+            font-size: 0;
         }
 
         .info-icon::after {

--- a/faq.html
+++ b/faq.html
@@ -446,11 +446,13 @@
 
         .info-icon {
             display: inline-block;
+            width: 1em;
+            height: 1em;
             margin-left: 4px;
-            color: #4f46e5;
+            background: url('https://storage.googleapis.com/art_homelessness/tool%20tip%20question%20mark.png') no-repeat center/contain;
             cursor: pointer;
             position: relative;
-            font-weight: 600;
+            font-size: 0;
         }
 
         .info-icon::after {

--- a/index.html
+++ b/index.html
@@ -1927,11 +1927,13 @@
         /* Tooltip icon */
         .info-icon {
             display: inline-block;
+            width: 1em;
+            height: 1em;
             margin-left: 4px;
-            color: var(--primary);
+            background: url('https://storage.googleapis.com/art_homelessness/tool%20tip%20question%20mark.png') no-repeat center/contain;
             cursor: pointer;
             position: relative;
-            font-weight: 600;
+            font-size: 0;
         }
 
         .info-icon::after {


### PR DESCRIPTION
## Summary
- swap default ℹ️ tooltip marker for custom question mark PNG across card, FAQ, and index pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5f66d03f483328803f8e065e1ee4a