### PR TITLE
Add ReadyNow app with default home link

### DIFF
--- a/home.html
+++ b/home.html
@@ -213,8 +213,13 @@
 
     let editMode = false;
     let favoriteApps = JSON.parse(localStorage.getItem('protonBookmarks') || '[]').filter(Boolean);
+    if (favoriteApps.length === 0) {
+      favoriteApps = ['readynow'];
+      localStorage.setItem('protonBookmarks', JSON.stringify(favoriteApps));
+    }
 
     const PROTON_APPS = [
+      { id: 'readynow', name: 'ReadyNow', url: 'readynow.html', icon: 'https://www.literacypittsburgh.org/uploads/thumb/website-news-template-(1)_008.png' },
       { id: 'mail', name: 'Proton Mail', url: 'https://account.proton.me/mail', icon: 'https://pmecdn.protonweb.com/image-transformation/?s=c&image=image%2Fupload%2Fstatic%2Flogos%2Ficons%2Fmail_xxy4bg.svg' },
       { id: 'drive', name: 'Proton Drive', url: 'https://drive.proton.me/', icon: 'https://pmecdn.protonweb.com/image-transformation/?s=c&image=image%2Fupload%2Fstatic%2Flogos%2Ficons%2Fdrive_wo2nx4.svg' },
       { id: 'vpn', name: 'Proton VPN', url: 'https://account.protonvpn.com/dashboard', icon: 'https://pmecdn.protonweb.com/image-transformation/?s=c&image=image%2Fupload%2Fstatic%2Flogos%2Ficons%2Fvpn_f9embt.svg' },

--- a/readynow.html
+++ b/readynow.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ReadyNow</title>
+    <script src="scripts/translate.js"></script>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif; margin: 0; padding: 20px; text-align: center; }
+        .skip-link { position: absolute; top: -40px; left: 0; background: #fff; color: #000; padding: 8px 16px; z-index: 1000; }
+        .skip-link:focus { top: 0; }
+        .store-links { display: flex; justify-content: center; gap: 20px; margin-top: 20px; flex-wrap: wrap; }
+        .store-links img { max-width: 150px; height: auto; }
+        img.screenshot { max-width: 100%; height: auto; border-radius: 8px; }
+    </style>
+</head>
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <main id="main-content">
+        <h1>ReadyNow</h1>
+        <img class="screenshot" src="https://www.literacypittsburgh.org/uploads/thumb/website-news-template-(1)_008.png" alt="ReadyNow app screenshot">
+        <div class="store-links">
+            <a href="https://apps.apple.com/us/app/readynow/id6744073026" target="_blank" rel="noopener noreferrer">
+                <img src="https://help.apple.com/assets/66E1DA28FC17C700AB060F10/66E1DA2CFC17C700AB060F16/en_US/5279f907b15e129c19254ca88d643cd9.png" alt="Download on the App Store">
+            </a>
+            <a href="https://play.google.com/store/apps/details?id=com.innovationlab.alertbuttonexpo&pcampaignid=web_share" target="_blank" rel="noopener noreferrer">
+                <img src="https://hcc.nl/images/2018/10/d8f_GooglePlay_mediumklein.jpg" alt="Get it on Google Play">
+            </a>
+        </div>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone ReadyNow page with image and store download buttons
- show ReadyNow in default favorites list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c70d93ae408332a5feb94d97e3b31e