### PR TITLE
Improve key banner readability and responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,14 +109,40 @@
             text-align: center;
             padding: 8px 10px;
             font-weight: 600;
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
         }
 
         .key-banner.hidden {
             display: none;
         }
 
+        #key-banner-text {
+            font-size: 1.25rem;
+        }
+
+        #key-banner-text .subheading {
+            display: block;
+            font-size: 0.85rem;
+            color: var(--secondary);
+            font-weight: 400;
+        }
+
         .key-banner .btn {
-            margin-left: 10px;
+            margin-left: 0;
+        }
+
+        @media (max-width: 480px) {
+            .key-banner {
+                flex-direction: column;
+            }
+
+            .key-banner .btn {
+                margin-top: 0.25rem;
+            }
         }
 
         #language-toggle {


### PR DESCRIPTION
## Summary
- Increase key banner title size and define contrasting subheading style
- Use flex layout with responsive media query so return button stacks below text on small screens

## Testing
- `npx --yes htmlhint index.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c7aaf51c08833287eadb59f40763fb