### PR TITLE
Add banner translations and modal styles

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -472,7 +472,12 @@
             "createIKeyButton": "Create iKey Emergency ID",
             "locationServices": "LOCATION SERVICES",
             "readyToShare": "Ready for emergency sharing",
-            "noAlerts": "No alerts"
+            "noAlerts": "No alerts",
+            "scannedBannerSubheading": "This iKey belongs to someone else. Your saved iKey is not affected.",
+            "setAsMyKey": "Set as My iKey",
+            "returnToMyKey": "Return to My iKey",
+            "replaceWarning": "Setting this as your iKey will replace your saved iKey. Continue?",
+            "cancel": "Cancel"
         },
         "card": {
             "title": "iKey ID Card Generator",
@@ -967,7 +972,12 @@
             "createIKeyButton": "Crear ID de emergencia iKey",
             "locationServices": "SERVICIOS DE UBICACIÓN",
             "readyToShare": "Listo para compartir en emergencia",
-            "noAlerts": "Sin alertas"
+            "noAlerts": "Sin alertas",
+            "scannedBannerSubheading": "Este iKey pertenece a otra persona. Tu iKey guardado no se ve afectado.",
+            "setAsMyKey": "Establecer como mi iKey",
+            "returnToMyKey": "Volver a mi iKey",
+            "replaceWarning": "Al establecer esto como tu iKey, se reemplazará tu iKey guardado. ¿Continuar?",
+            "cancel": "Cancelar"
         },
         "card": {
             "title": "Generador de Tarjeta de ID de iKey",
@@ -1452,7 +1462,12 @@
             "createIKeyButton": "إنشاء معرّف طوارئ iKey",
             "locationServices": "خدمات الموقع",
             "readyToShare": "جاهز للمشاركة في الطوارئ",
-            "noAlerts": "لا توجد تنبيهات"
+            "noAlerts": "لا توجد تنبيهات",
+            "scannedBannerSubheading": "هذا iKey يخص شخصًا آخر. لا يتأثر iKey المحفوظ لديك.",
+            "setAsMyKey": "تعيينه كـ iKey الخاص بي",
+            "returnToMyKey": "العودة إلى iKey الخاص بي",
+            "replaceWarning": "سيؤدي تعيين هذا كـ iKey الخاص بك إلى استبدال iKey المحفوظ لديك. هل تريد المتابعة؟",
+            "cancel": "إلغاء"
         },
         "card": {
             "title": "مولد بطاقة هوية iKey",
@@ -1931,7 +1946,12 @@
             "createIKeyButton": "Nasnameya FHN ya iKey biafirîne",
             "locationServices": "XIZMETA CIHÛHATÊ",
             "readyToShare": "Ji parvekirina fercî amade ye",
-            "noAlerts": "Hişyarî tune ye"
+            "noAlerts": "Hişyarî tune ye",
+            "scannedBannerSubheading": "Ev iKey ya kesekî din e. iKey'a te ya tomarkirî ne tê bandorkirin.",
+            "setAsMyKey": "Wekî iKey'a min saz bike",
+            "returnToMyKey": "Vegere iKey'a min",
+            "replaceWarning": "Heke ev wekî iKey'a xwe saz bikî, iKey'a tomarkirî ya te dê were guherandin. Bixwazî bidomînî?",
+            "cancel": "Betalke"
         },
         "misc": {
             "apps": "Proton Apps",
@@ -2309,7 +2329,12 @@
             "createIKeyButton": "Samee Aqoonsiga Degdegga iKey",
             "locationServices": "ADEEGYADA GOOBTA",
             "readyToShare": "Diyaar u ah wadaagga degdegga ah",
-            "noAlerts": "Wax digniin ah ma jiraan"
+            "noAlerts": "Wax digniin ah ma jiraan",
+            "scannedBannerSubheading": "iKey-kan wuxuu leeyahay qof kale. iKey-gaaga kaydsan ma saameynayo.",
+            "setAsMyKey": "U deji sida iKey-gayga",
+            "returnToMyKey": "Ku noqo iKey-gayga",
+            "replaceWarning": "Haddii aad tan u dejiso sidii iKey-gaaga, iKey-ga kaydsan waa la beddeli doonaa. Ma doonaysaa inaad sii waddo?",
+            "cancel": "Jooji"
         },
         "misc": {
             "apps": "Proton Apps",
@@ -2687,7 +2712,12 @@
             "createIKeyButton": "创建 iKey 紧急 ID",
             "locationServices": "定位服务",
             "readyToShare": "已准备好紧急共享",
-            "noAlerts": "无警报"
+            "noAlerts": "无警报",
+            "scannedBannerSubheading": "此 iKey 属于他人。你保存的 iKey 不受影响。",
+            "setAsMyKey": "设为我的 iKey",
+            "returnToMyKey": "返回我的 iKey",
+            "replaceWarning": "将其设为你的 iKey 会替换你已保存的 iKey。是否继续？",
+            "cancel": "取消"
         },
         "misc": {
             "apps": "Proton Apps",

--- a/index.html
+++ b/index.html
@@ -119,6 +119,16 @@
             margin-left: 10px;
         }
 
+        .my-key-banner {
+            background: #dcfce7;
+            color: var(--success);
+        }
+
+        .scanned-key-banner {
+            background: #fef3c7;
+            color: var(--warning);
+        }
+
         #language-toggle {
             position: absolute;
             top: 10px;
@@ -1283,6 +1293,20 @@
         .modal-actions input:focus {
             outline: none;
             border-color: var(--primary);
+        }
+
+        .modal-button {
+            padding: 12px 20px;
+            border-radius: var(--radius);
+            border: 2px solid var(--border);
+            background: white;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .modal-button:hover {
+            background: var(--light);
         }
         .qr-modal-content {
             width: 90%;


### PR DESCRIPTION
## Summary
- add banner and modal translations across supported languages
- style new key banners and modal buttons for consistent UX

## Testing
- `python -m json.tool TRANSLATION_TERMS.md`
- `node -e "function hexToRgb(h){const b=h.replace('#','');return [0,1,2].map(i=>parseInt(b.substr(i*2,2),16)/255);}function lum([r,g,b]){[r,g,b]=[r,g,b].map(c=>c<=0.03928?c/12.92:Math.pow((c+0.055)/1.055,2.4));return 0.2126*r+0.7152*g+0.0722*b;}function contrast(h1,h2){const L1=lum(hexToRgb(h1));const L2=lum(hexToRgb(h2));const [hi,lo]=L1>L2?[L1,L2]:[L2,L1];return ((hi+0.05)/(lo+0.05)).toFixed(2);}console.log('my-key-banner',contrast('#0f5132','#dcfce7'));console.log('scanned-key-banner',contrast('#92400e','#fef3c7'));"`


------
https://chatgpt.com/codex/tasks/task_b_68c7aaf699348332a9805f2414b2e5db