### PR TITLE
Add localized Set My Key modal

### DIFF
--- a/TRANSLATION_TERMS.md
+++ b/TRANSLATION_TERMS.md
@@ -461,6 +461,13 @@
             "crisisLine": "Suicide & Crisis Lifeline: 988",
             "poisonControlNumber": "Poison Control: 1-800-222-1222"
         },
+        "setKeyModal": {
+            "title": "Set as My iKey?",
+            "body": "Set %s as My iKey on this device?",
+            "replaceWarning": "This will replace your saved key for %s.",
+            "cancel": "Cancel",
+            "confirm": "Set as My iKey"
+        },
         "home": {
             "myIKey": "My iKey",
             "scannedCard": "Scanned Card",
@@ -956,6 +963,13 @@
             "crisisLine": "Línea de Suicidio y Crisis: 988",
             "poisonControlNumber": "Control de Venenos: 1-800-222-1222"
         },
+        "setKeyModal": {
+            "title": "¿Guardar como mi iKey?",
+            "body": "¿Guardar %s como mi iKey en este dispositivo?",
+            "replaceWarning": "Esto reemplazará tu llave guardada para %s.",
+            "cancel": "Cancelar",
+            "confirm": "Establecer como mi iKey"
+        },
         "home": {
             "myIKey": "Mi iKey",
             "scannedCard": "Tarjeta escaneada",
@@ -1441,6 +1455,13 @@
             "crisisLine": "خط الأزمات والانتحار: 988",
             "poisonControlNumber": "مراقبة السموم: 1-800-222-1222"
         },
+        "setKeyModal": {
+            "title": "تعيين كمفتاحي؟",
+            "body": "تعيين %s كمفتاحي على هذا الجهاز؟",
+            "replaceWarning": "سيؤدي ذلك إلى استبدال المفتاح المحفوظ لـ %s.",
+            "cancel": "إلغاء",
+            "confirm": "تعيين كمفتاحي"
+        },
         "home": {
             "myIKey": "مفتاحي iKey",
             "scannedCard": "بطاقة ممسوحة",
@@ -1920,6 +1941,13 @@
             "crisisLine": "Xeta Xwekujtin û Krîzê: 988",
             "poisonControlNumber": "Kontrola Jehrê: 1-800-222-1222"
         },
+        "setKeyModal": {
+            "title": "Bibihêle wekî iKey a min?",
+            "body": "%s wekî iKey a min li vê cîhazê saz bikim?",
+            "replaceWarning": "Ev ê mifteya tomarkirî ya %s biguhezîne.",
+            "cancel": "Betal",
+            "confirm": "Wekî iKey a min saz bike"
+        },
         "home": {
             "myIKey": "iKey-a min",
             "scannedCard": "Kartê şopandî",
@@ -2298,6 +2326,13 @@
             "crisisLine": "Khadka Ismiidaaminta & Dhibaatada: 988",
             "poisonControlNumber": "Xakamaynta Sunta: 1-800-222-1222"
         },
+        "setKeyModal": {
+            "title": "U deji iKeygeyga?",
+            "body": "Ma rabtaa in %s laga dhigo iKeygeyga qalabkan?",
+            "replaceWarning": "Tani waxay beddeli doontaa furaha aad kaydisay ee %s.",
+            "cancel": "Ka noqo",
+            "confirm": "U deji iKeygeyga"
+        },
         "home": {
             "myIKey": "iKey-gayga",
             "scannedCard": "Kaarka la sawiray",
@@ -2675,6 +2710,13 @@
             "policeDispatch": "纳什维尔警察调度",
             "crisisLine": "自杀与危机生命线：988",
             "poisonControlNumber": "中毒控制：1-800-222-1222"
+        },
+        "setKeyModal": {
+            "title": "设为我的 iKey？",
+            "body": "在此设备上将 %s 设为我的 iKey？",
+            "replaceWarning": "这将替换你为 %s 保存的密钥。",
+            "cancel": "取消",
+            "confirm": "设为我的 iKey"
         },
         "home": {
             "myIKey": "我的 iKey",

--- a/index.html
+++ b/index.html
@@ -2541,7 +2541,7 @@
                 <button class="btn btn-primary" onclick="confirmLocationRequest()" data-i18n="location.share">Share Location</button><span class="info-icon" tabindex="0" data-tooltip="Gets GPS from your device; nothing is stored or sent automatically.">ℹ️</span>
             </div>
         </div>
-    </div>
+</div>
 </div>
 
 <!-- About Modal -->
@@ -2557,6 +2557,24 @@
             <p data-i18n="about.security">You can set a password to encrypt your saved data so only you can read it.</p>
             <p data-i18n="about.clear">To clear your data, open your browser settings and remove site data for this page or use the "Clear browsing data" option.</p>
             <p data-i18n="about.trainingLink"><a href="resources/training/index.html">Training Materials</a></p>
+        </div>
+    </div>
+</div>
+
+<!-- Set My Key Modal -->
+<div id="set-my-key-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="set-my-key-title" tabindex="-1" aria-hidden="true">
+    <div class="modal-content" style="max-width: 500px;">
+        <div class="modal-header" style="padding: 20px; border-bottom: 1px solid var(--border);">
+            <h3 id="set-my-key-title" data-i18n="setKeyModal.title" style="margin: 0;">Set as My iKey?</h3>
+            <button class="modal-close" onclick="closeSetMyKeyModal()">×</button>
+        </div>
+        <div style="padding: 20px;">
+            <p id="set-my-key-text"></p>
+            <p id="set-my-key-warning" style="color: var(--danger); font-weight: 600;"></p>
+            <div class="modal-actions" style="margin-top: 20px; display: flex; gap: 10px; justify-content: flex-end;">
+                <button class="btn btn-secondary" onclick="closeSetMyKeyModal()" data-i18n="setKeyModal.cancel">Cancel</button>
+                <button class="btn btn-primary" onclick="handleSetMyKeyConfirm()" data-i18n="setKeyModal.confirm">Set as My iKey</button>
+            </div>
         </div>
     </div>
 </div>
@@ -3312,16 +3330,54 @@ let lastGeneratedDataString = null;
 let lastGeneratedPhoto = '';
 let dataListenersSet = false;
 let pendingMyKeyHash = null;
+let setMyKeyPending = { email: null, hash: null, name: null };
 
 updateWizardDisplay();
 
-function promptSetAsMyKey(email, hash, name) {
+function showSetMyKeyModal(email, hash, name) {
     if (!email) return;
-    if (confirm('Set this as my iKey on this device?')) {
-        if (hash) localStorage.setItem('myKeyData', hash);
-        localStorage.setItem('myKeyEmail', email);
-        if (name) localStorage.setItem('myKeyName', name);
+    setMyKeyPending = { email, hash, name };
+    const modal = document.getElementById('set-my-key-modal');
+    if (!modal) return;
+    const textEl = document.getElementById('set-my-key-text');
+    const warnEl = document.getElementById('set-my-key-warning');
+    const label = name || email;
+    textEl.textContent = t('setKeyModal.body').replace('%s', label);
+    const existingName = localStorage.getItem('myKeyName');
+    const existingEmail = localStorage.getItem('myKeyEmail');
+    if (existingName || existingEmail) {
+        const existing = existingName || existingEmail;
+        warnEl.textContent = t('setKeyModal.replaceWarning').replace('%s', existing);
+    } else {
+        warnEl.textContent = '';
     }
+    lastFocusedElement = document.getElementById('back-to-my-key');
+    if (!lastFocusedElement) {
+        lastFocusedElement = document.getElementById('display-view');
+        if (lastFocusedElement) lastFocusedElement.setAttribute('tabindex', '-1');
+    }
+    modal.classList.remove('hidden');
+    modal.setAttribute('aria-hidden', 'false');
+    trapFocus(modal, closeSetMyKeyModal);
+}
+
+function closeSetMyKeyModal() {
+    const modal = document.getElementById('set-my-key-modal');
+    if (modal) {
+        modal.classList.add('hidden');
+        modal.setAttribute('aria-hidden', 'true');
+        releaseFocus(modal);
+    }
+}
+
+function handleSetMyKeyConfirm() {
+    const { email, hash, name } = setMyKeyPending;
+    if (!email) return;
+    if (hash) localStorage.setItem('myKeyData', hash);
+    localStorage.setItem('myKeyEmail', email);
+    if (name) localStorage.setItem('myKeyName', name);
+    closeSetMyKeyModal();
+    updateKeyBanner();
 }
 
         function compressData(data) {
@@ -3718,7 +3774,7 @@ function promptSetAsMyKey(email, hash, name) {
 
             displayData = cleanData;
             renderHomeStatus();
-            promptSetAsMyKey(cleanData.pe, compressed, cleanData.n);
+            showSetMyKeyModal(cleanData.pe, compressed, cleanData.n);
             updateKeyBanner();
 
             document.getElementById('wizard-view').classList.add('hidden');
@@ -5675,7 +5731,7 @@ Generated: ${new Date().toLocaleString()}`;
             displayData = data;
             renderHomeStatus();
             if (pendingMyKeyHash && data.pe) {
-                promptSetAsMyKey(data.pe, pendingMyKeyHash, data.n);
+                showSetMyKeyModal(data.pe, pendingMyKeyHash, data.n);
                 pendingMyKeyHash = null;
             }
             updateKeyBanner();


### PR DESCRIPTION
## Summary
- Add accessible Set My Key modal with cancel and confirm actions
- Replace confirm prompts with modal and restore focus on close
- Localize new modal text and update translation terms

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c7aaf35efc8332b809060fbe04df26