### PR TITLE
Fix missing brace in home page favorites script

### DIFF
--- a/home.html
+++ b/home.html
@@ -215,6 +215,7 @@
     let favoriteApps = JSON.parse(localStorage.getItem('protonBookmarks') || '[]').filter(Boolean);
     if (!favoriteApps.includes('readynow')) {
       favoriteApps.unshift('readynow');
+    }
 
     if (favoriteApps.length === 0) {
       favoriteApps = ['readynow'];


### PR DESCRIPTION
## Summary
- close the default favorites initialization block so subsequent logic runs correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c9b94114bc8332ac9b261996dca3b4