### PR TITLE
Fix initialization timing and default favorites

### DIFF
--- a/home.html
+++ b/home.html
@@ -213,13 +213,17 @@
 
     let editMode = false;
     let favoriteApps = JSON.parse(localStorage.getItem('protonBookmarks') || '[]').filter(Boolean);
-    if (!favoriteApps.includes('readynow')) {
-      favoriteApps.unshift('readynow');
-    }
+    let favoritesUpdated = false;
 
     if (favoriteApps.length === 0) {
       favoriteApps = ['readynow'];
+      favoritesUpdated = true;
+    } else if (!favoriteApps.includes('readynow')) {
+      favoriteApps.unshift('readynow');
+      favoritesUpdated = true;
+    }
 
+    if (favoritesUpdated) {
       localStorage.setItem('protonBookmarks', JSON.stringify(favoriteApps));
     }
 

--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -65,4 +65,8 @@ window.translateFragment = translateFragment;
 window.t = t;
 window.setLanguage = setLanguage;
 
-document.addEventListener('DOMContentLoaded', loadTranslations);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', loadTranslations, { once: true });
+} else {
+  loadTranslations();
+}


### PR DESCRIPTION
## Summary
- ensure translation loading runs even when the bundle is inserted after DOMContentLoaded so inline initialization keeps working
- persist the default ReadyNow favorite in localStorage when the home page first initializes or when it has been removed

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68c9c1c6f5b883329a74686e017f311c