### PR TITLE
Fix home page initialization for wizard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3194,6 +3194,9 @@
             get: (key) => localStorage.getItem(`${storagePrefix}_${key}`),
             set: (key, value) => localStorage.setItem(`${storagePrefix}_${key}`, value)
         };
+        let displayData = null;
+        let isOwnKey = false;
+        let bookmarkManager;
 
         // Toggle resource dropdown
         function toggleResourceMenu() {
@@ -5229,8 +5232,6 @@ END:VCALENDAR`;
             }
         }
 
-        let bookmarkManager;
-
         const CODE_ALPHABET = '23456789CFGHJMPQRVWX';
 
         function encodePlusCode(latitude, longitude) {
@@ -5698,9 +5699,6 @@ Generated: ${new Date().toLocaleString()}`;
                 loadWeatherForCity(cityName);
             }
         }
-
-        let displayData = null;
-        let isOwnKey = false;
 
         function showEmergencyModal(data) {
             const modal = document.getElementById('emergency-modal');


### PR DESCRIPTION
## Summary
- declare the home view state (`displayData`, `isOwnKey`, `bookmarkManager`) before early initialization code runs so the home tab and wizard no longer throw temporal dead zone errors
- remove the duplicate state declarations from later in the file after relocating them to the shared top-level scope

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68c9cd7505308332b4384df9382d82db