### PR TITLE
Fix translation loading for nested pages

### DIFF
--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -1,6 +1,19 @@
 const translations = {};
+
+function getTranslationsUrl() {
+  try {
+    const currentScript = document.currentScript || document.querySelector('script[src*="translate.js"]');
+    if (currentScript && currentScript.src) {
+      return new URL('../TRANSLATION_TERMS.md', currentScript.src).toString();
+    }
+  } catch (err) {
+    console.warn('Unable to resolve translation URL from script tag, falling back to relative path.', err);
+  }
+  return 'TRANSLATION_TERMS.md';
+}
+
 function loadTranslations() {
-  return fetch('TRANSLATION_TERMS.md')
+  return fetch(getTranslationsUrl())
     .then(resp => resp.text())
     .then(text => {
       try {


### PR DESCRIPTION
## Summary
- resolve the translation manifest URL relative to the translate.js script so nested pages fetch the JSON successfully
- keep the existing relative fallback and log when the script URL cannot be resolved

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68ca201338fc83329452f38d1260ecf9